### PR TITLE
fix: supprimer le champ dénormalisé evenements.parcelle (migration v12)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,48 @@ Config is loaded from `.env.{APP_ENV}` via `config.py`.
 
 ### Entry Points
 
-**bot.py** — Telegram bot. Handles voice notes (transcribed via Whisper) and text commands. Key handlers: `/parse` (log event), `/ask` (analytics question), `/stats`, `/plan`, `/parcelle`. Runs a daily 5am job to fetch weather via Open-Meteo.
+**bot.py** — Telegram bot. Handles voice notes (transcribed via Whisper) and text commands. Runs a daily 5am job to fetch weather via Open-Meteo.
+
+#### Telegram Bot — Commandes slash
+
+| Commande | Description |
+|----------|-------------|
+| `/start` | Menu principal + compteur d'événements |
+| `/help` | Aide générale |
+| `/help parcelle` | Aide ciblée — mots-clés : `parcelle`, `semis`, `godet`, `recolte`, `stock`, `stats` |
+| `/stats` | Statistiques saison (végétatif vs reproducteur) |
+| `/stats <culture>` | Détail par variété pour une culture donnée |
+| `/historique` | 10 derniers événements |
+| `/ask <question>` | Question analytique en langage naturel (ou `/ask` seul puis saisie) |
+| `/corriger` | Lancer le flux de correction d'un événement existant |
+| `/plan` | Plan d'occupation global du potager |
+| `/plan <parcelle>` | Plan détaillé d'une parcelle spécifique |
+| `/parcelle ajouter <nom> [exposition] [superficie]` | Créer une parcelle (détection de doublons) |
+| `/parcelle modifier <nom> clé=valeur …` | Modifier les métadonnées (`exposition`, `superficie`, `ordre`) |
+| `/parcelle renommer <ancien> <nouveau>` | Renommer (propagation sur tout l'historique) |
+| `/parcelle lister` | Lister toutes les parcelles |
+| `/parcelles` | Alias de `/parcelle lister` |
+| `/meteo` | Récupérer et afficher la météo manuellement (job auto à 05h00) |
+| `/tts` | Afficher l'état de la synthèse vocale |
+| `/tts_on` | Activer les réponses vocales |
+| `/tts_off` | Désactiver les réponses vocales |
+
+#### Clavier inline (boutons persistants)
+
+Menu principal : `🎤 Nouvelle action vocale` · `🔍 Interroger` · `📋 Historique` · `📊 Stats` · `✏️ Corriger`
+
+Après enregistrement : `➕ Autre action` · `🔍 Interroger mes données` · `📋 Historique` · `🏠 Menu principal`
+
+#### Intents vocaux reconnus (classification Groq)
+
+`ACTION` · `INTERROGER` · `STATS` · `HISTORIQUE` · `PLAN` · `CORRIGER` · `SUPPRIMER` · `MENU` · `NOUVELLE`
+
+#### Flux de correction conversationnel (`/corriger`)
+
+1. Décrire l'événement à retrouver (ou taper `1` pour le dernier)
+2. Sélectionner parmi les candidats trouvés
+3. Dicter la correction en langage naturel
+4. Confirmer le résumé des modifications
 
 **main.py** — FastAPI server. Key endpoints: `POST /parse`, `POST /ask`, `GET /stats`, `GET /historique`, `GET /cultures`. Serves PWA static files.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,112 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Langue
+
+Toujours répondre en français, quelle que soit la langue utilisée dans les messages.
+
+## Project Overview
+
+**Assistant Potager** is an intelligent gardening tracker for amateur gardeners. It combines:
+- A **Telegram Bot** (bot.py) for voice/text command input
+- A **FastAPI REST API** (main.py) serving a Progressive Web App
+- **PostgreSQL** for event storage
+- **Groq LLM** (Llama 3.3-70b + Whisper) for natural language parsing and analytics
+
+The core flow: user dictates a gardening event → Groq extracts structured JSON → normalized and stored as an `Evenement` linked to a `Parcelle`.
+
+## Commands
+
+```bash
+# Install dependencies
+pip install -r requirements.txt
+
+# Run tests (uses SQLite in-memory, no PostgreSQL needed)
+pytest tests/
+pytest tests/test_us006_renommer_parcelle.py   # single test file
+pytest tests/ -k "test_name"                   # single test by name
+
+# Start Telegram bot
+python bot.py
+
+# Start FastAPI server (http://localhost:8000)
+python main.py
+
+# Apply latest database migration
+psql -d potager -f migrations/migration_v12.sql
+
+# Redéployer l'environnement dev local (pull + deps + migrations)
+.\update_dev.ps1
+.\update_dev.ps1 -SkipPull   # depuis un hook git
+.\update_dev.ps1 -Force      # tout rejouer
+```
+
+## Environment Setup
+
+Copy `.env.example` to `.env.dev` and fill in:
+- `APP_ENV` — `dev` or `prod`
+- `TELEGRAM_BOT_TOKEN`
+- `GROQ_API_KEY`
+- `DATABASE_URL` — PostgreSQL connection string
+
+Config is loaded from `.env.{APP_ENV}` via `config.py`.
+
+## Architecture
+
+### Entry Points
+
+**bot.py** — Telegram bot. Handles voice notes (transcribed via Whisper) and text commands. Key handlers: `/parse` (log event), `/ask` (analytics question), `/stats`, `/plan`, `/parcelle`. Runs a daily 5am job to fetch weather via Open-Meteo.
+
+**main.py** — FastAPI server. Key endpoints: `POST /parse`, `POST /ask`, `GET /stats`, `GET /historique`, `GET /cultures`. Serves PWA static files.
+
+### Core Modules
+
+| Module | Role |
+|--------|------|
+| `database/models.py` | SQLAlchemy models: `Evenement`, `Parcelle`, `CultureConfig` |
+| `llm/groq_client.py` | `parse_commande()`, `repondre_question()`, `extract_intent()` |
+| `utils/stock.py` | `calcul_stock_cultures()` — vegetative vs reproducteur crop logic |
+| `utils/parcelles.py` | Plot management, `normalize_parcelle_name()`, occupancy calc |
+| `utils/actions.py` | `normalize_action()`, `ACTION_MAP` keyword→canonical mapping |
+| `utils/date_utils.py` | `parse_date()` — ISO strings to datetime |
+| `utils/tts.py` | `send_voice_reply()`, TTS on/off state persisted in `utils/.tts_state.json` |
+| `utils/meteo.py` | Weather fetch from Open-Meteo (free, no API key) |
+
+### Data Model
+
+**Parcelles** — garden plots with a normalized name (`nom_normalise`: lowercase, no accents, no spaces/dashes). Soft-deleted via `actif` flag.
+
+**Evenements** — gardening events (plantings, harvests, losses, waterings, etc.) always linked to a `Parcelle` via `parcelle_id` (NOT NULL since migration v12). Key fields: `type_action`, `culture`, `variete`, `quantite`, `unite`, `date`, `type_organe_recolte`.
+
+**CultureConfig** — crop metadata, especially `type_organe_recolte`:
+- `végétatif` (lettuce, carrot, radish): harvest destroys the plant → stock decreases on harvest
+- `reproducteur` (tomato, zucchini, pepper): harvest is independent → stock only decreases on loss
+
+### Canonical Action Names
+
+`recolte`, `semis`, `plantation`, `arrosage`, `desherbage`, `taille`, `paillage`, `tuteurage`, `fertilisation`, `observation`, `perte`, `mise_en_godet`
+
+## Database Migrations
+
+Manual SQL files in `migrations/`, numbered sequentially (v2 → v12). Apply in order on a fresh DB. Latest: `migration_v12.sql` — removes the denormalized `evenements.parcelle` text column; `parcelle_id` is now NOT NULL with FK.
+
+## Testing
+
+Tests are in `tests/`. `conftest.py` sets `APP_ENV=test` and `DATABASE_URL=sqlite:///:memory:`, so PostgreSQL is not required. Each test clears DB state via fixtures.
+
+User story tests follow the pattern `test_us*.py` and cover specific features end-to-end. The `tests/` directory has 13+ test files covering actions, API, bot, Groq mocks, and each user story.
+
+## Language & Conventions
+
+- **French throughout**: comments, variable names, LLM prompts, user-facing strings
+- **Logging**: centralized logger `log = logging.getLogger("potager")`
+- **Docstrings**: reference user stories as `[US-001]`, etc.
+- **Type hints**: Python 3.9+ syntax (`dict[str, X]`, `list[X]`)
+- Parcelle name normalization: `strip().lower()` + `unidecode()` + remove spaces/dashes
+
+## External Dependencies
+
+- **FFmpeg**: required for MP3→OGG/Opus conversion (Telegram voice replies); gracefully degraded if missing
+- **Open-Meteo**: weather API (free, no key)
+- **Groq**: LLM API — models configured in `.env` as `GROQ_MODEL` and `GROQ_WHISPER_MODEL`

--- a/PATCH_NOTES.md
+++ b/PATCH_NOTES.md
@@ -1,4 +1,16 @@
 
+## [v2.14.1] — 2026-04-16
+
+### 🐛 Corrections
+- Corrige le crash de `/corriger` (`DetachedInstanceError`) causé par la migration v12 : `e.parcelle` déclenchait un lazy load SQLAlchemy après fermeture de session dans `_corr_start`, `_corr_search`, `_corr_select` et `_corr_confirm`
+- Corrige l'affichage de `1504 kg` au lieu de `5.5 kg` dans `/stats` : les récoltes en unités mixtes (kg/g) étaient additionnées sans normalisation dans `calcul_stock_cultures`
+- Corrige les récoltes sans variété ignorées dans `/stats [culture]` : elles sont désormais rattachées à la variété plantée quand une seule variété existe, ou affichées sous "Variété non précisée" sinon
+
+### 🔧 Améliorations techniques
+- Ajoute `selectinload(Evenement.parcelle_rel)` dans `_find_candidates` pour charger la relation en session avant fermeture
+- Extrait la logique de normalisation d'unités (`_to_g` / `_best_unite`) dans `calcul_stock_cultures`, cohérente avec `calcul_semis`
+- Met à jour `CLAUDE.md` avec la liste complète des commandes Telegram (17 commandes slash, claviers inline, intents vocaux, flux correction)
+
 ## [v2.14.0] — 2026-04-13
 
 ### 🚀 Nouveautés

--- a/bot.py
+++ b/bot.py
@@ -2057,10 +2057,11 @@ JSON brut uniquement."""
     log.info(f"🔎 CRITÈRES RECHERCHE : {criteres}")
 
     from unidecode import unidecode as _uni
+    from sqlalchemy.orm import selectinload
 
     db = SessionLocal()
     try:
-        q = db.query(Evenement)
+        q = db.query(Evenement).options(selectinload(Evenement.parcelle_rel))
         if criteres.get("action"):
             q = q.filter(Evenement.type_action == criteres["action"])
         if criteres.get("culture"):
@@ -2113,15 +2114,17 @@ async def _corr_start(update: Update, ctx: ContextTypes.DEFAULT_TYPE):
     db = SessionLocal()
     try:
         last = db.query(Evenement).order_by(Evenement.id.desc()).first()
+        last_id  = last.id          if last else None
+        last_fmt = _fmt_event(last) if last else None
     finally:
         db.close()
 
     ctx.user_data['mode'] = 'corr_search'
-    ctx.user_data['corr_last_id'] = last.id if last else None
+    ctx.user_data['corr_last_id'] = last_id
 
     txt = "✏️ *Mode correction*\n\nDécrivez l'action à retrouver :\n_Ex : récolte de tomates du 11 mars, dernier arrosage, paillage courgettes..._"
-    if last:
-        txt += f"\n\n_Ou tapez_ *1* _pour sélectionner directement le dernier :_\n`{_fmt_event(last)}`"
+    if last_fmt:
+        txt += f"\n\n_Ou tapez_ *1* _pour sélectionner directement le dernier :_\n`{last_fmt}`"
 
     await update.message.reply_text(
         txt, parse_mode="Markdown",
@@ -2142,11 +2145,13 @@ async def _corr_search(update: Update, ctx: ContextTypes.DEFAULT_TYPE, texte: st
         try:
             event = db.get(Evenement, ctx.user_data['corr_last_id'])
             candidates = [event] if event else []
+            candidates_fmt = [_fmt_event(e) for e in candidates]
         finally:
             db.close()
     else:
         msg_wait = await update.message.reply_text("🔎 Recherche en cours...")
-        candidates = _find_candidates(texte)
+        candidates = _find_candidates(texte)  # charge déjà parcelle_rel via selectinload
+        candidates_fmt = [_fmt_event(e) for e in candidates]
         try:
             await msg_wait.delete()
         except Exception:
@@ -2171,7 +2176,7 @@ async def _corr_search(update: Update, ctx: ContextTypes.DEFAULT_TYPE, texte: st
         ctx.user_data['corr_event_id'] = e.id
         ctx.user_data['mode'] = 'corr_apply'   # ← clé du fix
         await update.message.reply_text(
-            f"✅ Événement trouvé :\n\n`{_fmt_event(e)}`\n\n"
+            f"✅ Événement trouvé :\n\n`{candidates_fmt[0]}`\n\n"
             f"✏️ Dites-moi ce que vous souhaitez modifier :\n"
             f"_Ex : c'est 3 kg / la date c'est le 9 mars / ajouter parcelle nord_\n\n"
             f"Ou : [🗑 Supprimer] pour effacer cet événement.",
@@ -2183,8 +2188,8 @@ async def _corr_search(update: Update, ctx: ContextTypes.DEFAULT_TYPE, texte: st
         )
     else:
         lines = ["*Plusieurs événements trouvés, lequel voulez-vous modifier ?*\n"]
-        for i, e in enumerate(candidates, 1):
-            lines.append(f"*{i}.* `{_fmt_event(e)}`")
+        for i, fmt in enumerate(candidates_fmt, 1):
+            lines.append(f"*{i}.* `{fmt}`")
         btns = [[str(i) for i in range(1, len(candidates)+1)], ["❌ Annuler"]]
         await update.message.reply_text(
             "\n".join(lines), parse_mode="Markdown",
@@ -2219,6 +2224,7 @@ async def _corr_select(update: Update, ctx: ContextTypes.DEFAULT_TYPE, texte: st
     db = SessionLocal()
     try:
         event = db.get(Evenement, event_id)
+        event_fmt = _fmt_event(event) if event else None
     finally:
         db.close()
 
@@ -2231,7 +2237,7 @@ async def _corr_select(update: Update, ctx: ContextTypes.DEFAULT_TYPE, texte: st
     if "supprimer" in t:
         ctx.user_data['mode'] = 'corr_confirm_delete'
         await update.message.reply_text(
-            f"⚠️ *Confirmer la suppression ?*\n\n`{_fmt_event(event)}`\n\nCette action est irréversible.",
+            f"⚠️ *Confirmer la suppression ?*\n\n`{event_fmt}`\n\nCette action est irréversible.",
             parse_mode="Markdown",
             reply_markup=ReplyKeyboardMarkup(
                 [["✅ Oui, supprimer"], ["❌ Non, annuler"]], resize_keyboard=True
@@ -2243,7 +2249,7 @@ async def _corr_select(update: Update, ctx: ContextTypes.DEFAULT_TYPE, texte: st
     if t in ("✏️ corriger", "corriger"):
         ctx.user_data['mode'] = 'corr_apply'
         await update.message.reply_text(
-            f"✏️ Événement à corriger :\n\n`{_fmt_event(event)}`\n\n"
+            f"✏️ Événement à corriger :\n\n`{event_fmt}`\n\n"
             f"Dites-moi ce que vous souhaitez modifier :\n"
             f"_Ex : c'était 3 kg et non 2 / la date c'était le 10 mars / ajouter parcelle nord_",
             parse_mode="Markdown",
@@ -2266,7 +2272,7 @@ async def _corr_select(update: Update, ctx: ContextTypes.DEFAULT_TYPE, texte: st
     # Sinon : texte libre sans mot-clé → proposer les boutons
     ctx.user_data['corr_event_id'] = event_id
     await update.message.reply_text(
-        f"Événement sélectionné :\n\n`{_fmt_event(event)}`\n\nQue souhaitez-vous faire ?",
+        f"Événement sélectionné :\n\n`{event_fmt}`\n\nQue souhaitez-vous faire ?",
         parse_mode="Markdown",
         reply_markup=ReplyKeyboardMarkup(
             [["✏️ Corriger", "🗑 Supprimer"], ["❌ Annuler"]],
@@ -2482,10 +2488,11 @@ async def _corr_confirm(update: Update, ctx: ContextTypes.DEFAULT_TYPE, texte: s
         db = SessionLocal()
         try:
             event = db.get(Evenement, ctx.user_data['corr_event_id'])
+            event_fmt = _fmt_event(event) if event else "?"
         finally:
             db.close()
         await update.message.reply_text(
-            f"✏️ Que souhaitez-vous modifier d'autre ?\n\n`{_fmt_event(event)}`",
+            f"✏️ Que souhaitez-vous modifier d'autre ?\n\n`{event_fmt}`",
             parse_mode="Markdown",
             reply_markup=ReplyKeyboardMarkup([["❌ Annuler"]], resize_keyboard=True)
         )

--- a/bot.py
+++ b/bot.py
@@ -50,7 +50,7 @@ from sqlalchemy import func
 
 from config import GROQ_API_KEY, DATABASE_URL, TELEGRAM_BOT_TOKEN, GROQ_WHISPER_MODEL
 from database.db import SessionLocal, Base, engine
-from database.models import Evenement
+from database.models import Evenement, Parcelle
 from utils.actions import normalize_action
 from utils.parcelles import (
     calcul_occupation_parcelles, normalize_parcelle_name,
@@ -962,13 +962,15 @@ async def _parse_multi(update, lignes: list, msg=None):
         db = SessionLocal()
         try:
             for parsed in items:
+                nom_parcelle = parsed.get("parcelle")
+                parcelle_obj = resolve_parcelle(db, nom_parcelle) if nom_parcelle else None
                 event = Evenement(
                     type_action       = normalize_action(parsed.get("action")),
                     culture           = parsed.get("culture"),
                     variete           = parsed.get("variete"),
                     quantite          = _to_float(parsed.get("quantite")),
                     unite             = parsed.get("unite"),
-                    parcelle          = parsed.get("parcelle"),
+                    parcelle_id       = parcelle_obj.id if parcelle_obj else None,
                     rang              = _to_int(parsed.get("rang")),
                     duree             = _to_int(parsed.get("duree_minutes")),
                     traitement        = parsed.get("traitement"),
@@ -981,7 +983,7 @@ async def _parse_multi(update, lignes: list, msg=None):
                 db.add(event)
                 db.commit()
                 db.refresh(event)
-                log.info(f"  💾 DB SAVE : id={event.id} | action={event.type_action} | culture={event.culture} | date={event.date}")
+                log.info(f"  💾 DB SAVE : id={event.id} | action={event.type_action} | culture={event.culture} | parcelle_id={event.parcelle_id} | date={event.date}")
                 total_saved.append((parsed, event.id))
         except Exception as e:
             db.rollback()
@@ -1092,7 +1094,6 @@ async def _parse_and_save(update: Update, texte: str, msg=None):
                 variete           = parsed.get("variete"),
                 quantite          = _to_float(parsed.get("quantite")),
                 unite             = parsed.get("unite"),
-                parcelle          = parcelle_obj.nom if parcelle_obj else None,
                 parcelle_id       = parcelle_obj.id  if parcelle_obj else None,
                 rang              = _to_int(parsed.get("rang")),
                 duree             = _to_int(parsed.get("duree_minutes")),
@@ -2069,7 +2070,9 @@ JSON brut uniquement."""
             variete_val = criteres["variete"].strip()
             q = q.filter(Evenement.variete.ilike(f"%{variete_val}%"))
         if criteres.get("parcelle"):
-            q = q.filter(Evenement.parcelle.ilike(f"%{criteres['parcelle']}%"))
+            q = q.join(Parcelle, Evenement.parcelle_id == Parcelle.id, isouter=True).filter(
+                Parcelle.nom.ilike(f"%{criteres['parcelle']}%")
+            )
         if criteres.get("date_debut"):
             q = q.filter(Evenement.date >= criteres["date_debut"])
         if criteres.get("date_fin"):
@@ -2513,8 +2516,7 @@ async def _corr_confirm(update: Update, ctx: ContextTypes.DEFAULT_TYPE, texte: s
                 elif champ in ("rang", "duree_minutes"):
                     setattr(event, col, _to_int(valeur))
                 elif champ == "parcelle":
-                    # Mettre à jour le texte ET la FK parcelle_id
-                    event.parcelle    = valeur
+                    # [migration_v12] seule la FK parcelle_id est persistée
                     event.parcelle_id = corrections.get("_parcelle_id")
                 elif hasattr(event, col):
                     setattr(event, col, valeur)

--- a/database/models.py
+++ b/database/models.py
@@ -5,6 +5,7 @@ database/models.py — Modèles SQLAlchemy pour l'Assistant Potager
 [US-001] Ajout modèle CultureConfig (table culture_config)
 """
 from sqlalchemy import Column, Integer, String, Float, DateTime, Boolean, ForeignKey
+from sqlalchemy.orm import relationship
 from database.db import Base
 
 
@@ -28,7 +29,7 @@ class Evenement(Base):
     unite          = Column(String)
 
     # Localisation
-    parcelle       = Column(String, index=True)
+    # [migration_v12] colonne parcelle (texte dénormalisé) supprimée — parcelle_id est l'unique référence
     parcelle_id    = Column(Integer, ForeignKey("parcelles.id"), nullable=True, index=True)
     rang           = Column(Integer)   # [migration_v3] INTEGER (pas String)
 
@@ -47,6 +48,17 @@ class Evenement(Base):
     # [US_Enregistrer_mise_en_godet] Pépinière : nb graines semées → nb plants obtenus
     nb_graines_semees   = Column(Integer, nullable=True)
     nb_plants_godets    = Column(Integer, nullable=True)
+
+    # [migration_v12] Traçabilité pépinière : événement source (semis → godet → plantation)
+    origine_graines_id  = Column(Integer, ForeignKey("evenements.id", ondelete="SET NULL"), nullable=True)
+
+    # Relation vers la parcelle — permet d'accéder à e.parcelle_rel.nom
+    parcelle_rel = relationship("Parcelle", foreign_keys=[parcelle_id])
+
+    @property
+    def parcelle(self) -> str | None:
+        """Nom de la parcelle (compatibilité avec l'ancien champ texte dénormalisé)."""
+        return self.parcelle_rel.nom if self.parcelle_rel else None
 
 
 class CultureConfig(Base):

--- a/main.py
+++ b/main.py
@@ -18,8 +18,9 @@ from sqlalchemy import func
 import os
 
 from database.db import Base, engine, SessionLocal
-from database.models import Evenement, CultureConfig
+from database.models import Evenement, CultureConfig, Parcelle
 from utils.actions import normalize_action
+from utils.parcelles import resolve_parcelle
 from utils.stock import calcul_stock_cultures, format_stock_stats_json
 from llm.groq_client import parse_commande, repondre_question
 from utils.date_utils import parse_date
@@ -107,14 +108,15 @@ def parse(req: TexteRequest):
     saved = []
     try:
         for parsed in items:
+            nom_parcelle = parsed.get("parcelle")
+            parcelle_obj = resolve_parcelle(db, nom_parcelle) if nom_parcelle else None
             event = Evenement(
                 type_action    = normalize_action(parsed.get("action")),
                 culture        = parsed.get("culture"),
                 variete        = parsed.get("variete"),
-                produit        = parsed.get("culture"),
                 quantite       = _to_float(parsed.get("quantite")),
                 unite          = parsed.get("unite"),
-                parcelle       = parsed.get("parcelle"),
+                parcelle_id    = parcelle_obj.id if parcelle_obj else None,
                 rang           = parsed.get("rang"),
                 duree          = _to_int(parsed.get("duree_minutes")),
                 traitement     = parsed.get("traitement"),
@@ -247,7 +249,9 @@ def historique(
         if culture:
             q = q.filter(Evenement.culture.ilike(f"%{culture}%"))
         if parcelle:
-            q = q.filter(Evenement.parcelle.ilike(f"%{parcelle}%"))
+            q = q.join(Parcelle, Evenement.parcelle_id == Parcelle.id, isouter=True).filter(
+                Parcelle.nom.ilike(f"%{parcelle}%")
+            )
 
         events = q.limit(limit).all()
         return [

--- a/migrations/migration_v12.sql
+++ b/migrations/migration_v12.sql
@@ -1,0 +1,46 @@
+-- =============================================================================
+-- migration_v12.sql — Suppression du champ dénormalisé evenements.parcelle
+--                   + Ajout colonne origine_graines_id (traçabilité pépinière)
+-- =============================================================================
+-- Prérequis : migration_v11.sql (parcelle_id FK remplie)
+--
+-- Ce que fait cette migration :
+--   1. Crée la parcelle "Non localisé" pour les événements orphelins
+--   2. Assigne les orphelins (parcelle_id IS NULL) à cette parcelle
+--   3. Supprime la colonne evenements.parcelle (texte dénormalisé)
+--   4. Ajoute la colonne origine_graines_id (auto-FK pour traçabilité pépinière)
+--
+-- Idempotent : utilise IF NOT EXISTS / ON CONFLICT, safe à rejouer.
+--
+-- Exécution :
+--   psql -U potager_user -d potager -f migration_v12.sql
+-- =============================================================================
+
+-- [1] Créer la parcelle "Non localisé" pour les événements sans parcelle
+INSERT INTO parcelles (nom, nom_normalise, ordre, actif)
+VALUES ('Non localisé', 'nonlocalize', 9999, true)
+ON CONFLICT (nom_normalise) DO NOTHING;
+
+-- [2] Assigner les événements orphelins à "Non localisé"
+UPDATE evenements
+SET parcelle_id = (SELECT id FROM parcelles WHERE nom_normalise = 'nonlocalize')
+WHERE parcelle_id IS NULL;
+
+-- [3] Vérification : aucun événement ne doit rester sans parcelle_id
+SELECT COUNT(*) AS orphelins_restants FROM evenements WHERE parcelle_id IS NULL;
+-- Attendu : 0
+
+-- [4] Supprimer la colonne texte dénormalisée (PostgreSQL uniquement)
+ALTER TABLE evenements DROP COLUMN IF EXISTS parcelle;
+
+-- [5] Ajouter la colonne de traçabilité pépinière (semis → godet → plantation)
+ALTER TABLE evenements
+    ADD COLUMN IF NOT EXISTS origine_graines_id INTEGER
+        REFERENCES evenements(id) ON DELETE SET NULL;
+
+-- [6] Vérification post-migration
+SELECT
+    COUNT(*)                                                AS total_evenements,
+    COUNT(*) FILTER (WHERE parcelle_id IS NOT NULL)        AS avec_parcelle_fk,
+    COUNT(*) FILTER (WHERE origine_graines_id IS NOT NULL) AS avec_origine_graines
+FROM evenements;

--- a/tests/test_us006_renommer_parcelle.py
+++ b/tests/test_us006_renommer_parcelle.py
@@ -55,14 +55,14 @@ def _seed_parcelle(db: object, nom: str, ordre: int = 1) -> Parcelle:
     return p
 
 
-def _seed_evenements(db: object, parcelle_nom: str, nb: int) -> list:
-    """Crée nb événements liés à la parcelle (par nom textuel)."""
+def _seed_evenements(db: object, parcelle: Parcelle, nb: int) -> list:
+    """Crée nb événements liés à la parcelle (via parcelle_id FK)."""
     evts = []
     for i in range(nb):
         e = Evenement(
             type_action="plantation",
             culture="tomate",
-            parcelle=parcelle_nom,
+            parcelle_id=parcelle.id,
         )
         db.add(e)
         evts.append(e)
@@ -76,9 +76,9 @@ class TestRenameParcelle:
     """[CA2, CA3, CA4, CA5, CA6, CA7] Tests de la fonction rename_parcelle."""
 
     def test_renommage_nominal(self, db):
-        """[CA2, CA3, CA6] Renommage simple avec propagation sur les événements."""
-        _seed_parcelle(db, "sud", ordre=1)
-        _seed_evenements(db, "sud", 15)
+        """[CA2, CA3, CA6] Renommage simple — événements toujours liés via FK."""
+        parc_sud = _seed_parcelle(db, "sud", ordre=1)
+        _seed_evenements(db, parc_sud, 15)
 
         parc, nb = rename_parcelle(db, "sud", "carré-sud")
 
@@ -86,8 +86,8 @@ class TestRenameParcelle:
         assert parc.nom_normalise == "carresud"
         assert nb == 15
 
-        # Vérification en base
-        evts = db.query(Evenement).filter(Evenement.parcelle == "carré-sud").all()
+        # Via FK : tous les événements pointent toujours sur la même parcelle
+        evts = db.query(Evenement).filter(Evenement.parcelle_id == parc.id).all()
         assert len(evts) == 15
 
     def test_propagation_aucun_evenement(self, db):
@@ -101,8 +101,8 @@ class TestRenameParcelle:
 
     def test_insensible_casse(self, db):
         """[CA7] La résolution de l'ancien nom est insensible à la casse."""
-        _seed_parcelle(db, "Ouest", ordre=1)
-        _seed_evenements(db, "Ouest", 3)
+        parc_ouest = _seed_parcelle(db, "Ouest", ordre=1)
+        _seed_evenements(db, parc_ouest, 3)
 
         parc, nb = rename_parcelle(db, "OUEST", "ouest-jardin")
 
@@ -131,17 +131,16 @@ class TestRenameParcelle:
             rename_parcelle(db, "nord", "sud")
 
     def test_transaction_atomique(self, db):
-        """[CA2+CA3] Un seul commit — les deux mises à jour sont cohérentes."""
-        _seed_parcelle(db, "est", ordre=1)
-        _seed_evenements(db, "est", 5)
+        """[CA2+CA3] Un seul commit — parcelle renommée, 5 événements toujours liés."""
+        parc_est = _seed_parcelle(db, "est", ordre=1)
+        _seed_evenements(db, parc_est, 5)
 
         parc, nb = rename_parcelle(db, "est", "est-nouveau")
 
-        # Après commit, l'ancienne valeur ne doit plus exister
-        anciens_evts = db.query(Evenement).filter(Evenement.parcelle == "est").all()
-        nouveaux_evts = db.query(Evenement).filter(Evenement.parcelle == "est-nouveau").all()
-        assert len(anciens_evts) == 0
-        assert len(nouveaux_evts) == 5
+        # La parcelle est renommée et tous les événements lui sont toujours liés via FK
+        assert parc.nom == "est-nouveau"
+        assert nb == 5
+        assert db.query(Evenement).filter(Evenement.parcelle_id == parc.id).count() == 5
 
     def test_renommage_meme_nom_normalise_autre_casse(self, db):
         """

--- a/tests/test_us_006_renommer_parcelle.py
+++ b/tests/test_us_006_renommer_parcelle.py
@@ -78,10 +78,10 @@ def _cree_parcelle(db, nom: str, ordre: int = 1) -> Parcelle:
     return p
 
 
-def _cree_evenements(db, parcelle_nom: str, nb: int) -> list[Evenement]:
-    """Insère nb événements liés à la parcelle (par nom textuel)."""
+def _cree_evenements(db, parcelle: Parcelle, nb: int) -> list[Evenement]:
+    """Insère nb événements liés à la parcelle (via parcelle_id FK)."""
     evts = [
-        Evenement(type_action="plantation", culture="tomate", parcelle=parcelle_nom)
+        Evenement(type_action="plantation", culture="tomate", parcelle_id=parcelle.id)
         for _ in range(nb)
     ]
     db.add_all(evts)
@@ -127,20 +127,19 @@ class TestRenameParcelle:
     # ── CA3 ───────────────────────────────────────────────────────────────────
 
     def test_006_rename_ca3_propagation_evenements(self, db) -> None:
-        """[CA3] Tous les événements sont mis à jour avec le nouveau nom."""
+        """[CA3] Tous les événements restent liés à la parcelle renommée via FK."""
         # Arrange
-        _cree_parcelle(db, "est", ordre=1)
-        _cree_evenements(db, "est", 5)
+        parc_est = _cree_parcelle(db, "est", ordre=1)
+        _cree_evenements(db, parc_est, 5)
 
         # Act
         parc, nb = rename_parcelle(db, "est", "est-jardin")
 
         # Assert
         assert nb == 5
-        anciens = db.query(Evenement).filter(Evenement.parcelle == "est").count()
-        nouveaux = db.query(Evenement).filter(Evenement.parcelle == "est-jardin").count()
-        assert anciens == 0
-        assert nouveaux == 5
+        # Via FK : tous les événements pointent toujours sur la même parcelle (maintenant "est-jardin")
+        lies = db.query(Evenement).filter(Evenement.parcelle_id == parc.id).count()
+        assert lies == 5
 
     def test_006_rename_ca3_zero_evenement(self, db) -> None:
         """[CA3] Parcelle sans événements → nb retourné vaut 0."""
@@ -154,19 +153,19 @@ class TestRenameParcelle:
         assert nb == 0
 
     def test_006_rename_ca3_propagation_partielle(self, db) -> None:
-        """[CA3] Seuls les événements de la parcelle renommée sont modifiés."""
+        """[CA3] Seuls les événements de la parcelle renommée sont comptés."""
         # Arrange
-        _cree_parcelle(db, "nord", ordre=1)
-        _cree_parcelle(db, "sud", ordre=2)
-        _cree_evenements(db, "nord", 3)
-        _cree_evenements(db, "sud", 7)
+        parc_nord = _cree_parcelle(db, "nord", ordre=1)
+        parc_sud  = _cree_parcelle(db, "sud",  ordre=2)
+        _cree_evenements(db, parc_nord, 3)
+        _cree_evenements(db, parc_sud,  7)
 
         # Act
         _, nb = rename_parcelle(db, "nord", "nord-nouveau")
 
         # Assert — les événements "sud" ne bougent pas
         assert nb == 3
-        assert db.query(Evenement).filter(Evenement.parcelle == "sud").count() == 7
+        assert db.query(Evenement).filter(Evenement.parcelle_id == parc_sud.id).count() == 7
 
     # ── CA4 ───────────────────────────────────────────────────────────────────
 
@@ -213,8 +212,8 @@ class TestRenameParcelle:
     def test_006_rename_ca6_retour_tuple(self, db) -> None:
         """[CA6] La fonction retourne bien un tuple (Parcelle, int)."""
         # Arrange
-        _cree_parcelle(db, "parcelle-test", ordre=1)
-        _cree_evenements(db, "parcelle-test", 12)
+        parc_test = _cree_parcelle(db, "parcelle-test", ordre=1)
+        _cree_evenements(db, parc_test, 12)
 
         # Act
         resultat = rename_parcelle(db, "parcelle-test", "nouveau-nom")
@@ -230,8 +229,8 @@ class TestRenameParcelle:
     def test_006_rename_ca7_insensible_casse(self, db) -> None:
         """[CA7] L'ancien nom est résolu même si la casse est différente."""
         # Arrange
-        _cree_parcelle(db, "Ouest", ordre=1)
-        _cree_evenements(db, "Ouest", 3)
+        parc_ouest = _cree_parcelle(db, "Ouest", ordre=1)
+        _cree_evenements(db, parc_ouest, 3)
 
         # Act
         parc, nb = rename_parcelle(db, "OUEST", "ouest-jardin")
@@ -278,17 +277,18 @@ class TestRenameParcelle:
         assert parc.nom_normalise == "sud"
 
     def test_006_rename_edge_atomique(self, db) -> None:
-        """[CA2+CA3] Un seul commit : parcelle et événements cohérents."""
+        """[CA2+CA3] Un seul commit : parcelle renommée, événements toujours liés via FK."""
         # Arrange
-        _cree_parcelle(db, "milieu", ordre=1)
-        _cree_evenements(db, "milieu", 4)
+        parc_milieu = _cree_parcelle(db, "milieu", ordre=1)
+        _cree_evenements(db, parc_milieu, 4)
 
         # Act
-        rename_parcelle(db, "milieu", "centre")
+        parc, nb = rename_parcelle(db, "milieu", "centre")
 
-        # Assert — ancienne valeur effacée, nouvelle présente
-        assert db.query(Evenement).filter(Evenement.parcelle == "milieu").count() == 0
-        assert db.query(Evenement).filter(Evenement.parcelle == "centre").count() == 4
+        # Assert — la parcelle est renommée et les 4 événements lui sont toujours liés
+        assert parc.nom == "centre"
+        assert nb == 4
+        assert db.query(Evenement).filter(Evenement.parcelle_id == parc.id).count() == 4
 
 
 # ── Tests handler bot : cmd_parcelle renommer ─────────────────────────────────

--- a/tests/test_us_plan_occupation_parcelles.py
+++ b/tests/test_us_plan_occupation_parcelles.py
@@ -55,6 +55,10 @@ def db_with_cultures(test_db):
     db.add(CultureConfig(nom="tomate", type_organe_recolte="reproducteur"))
     db.add(CultureConfig(nom="salade", type_organe_recolte="végétatif"))
     db.add(CultureConfig(nom="basilic", type_organe_recolte="végétatif"))
+
+    # Parcelle de test
+    nord = Parcelle(nom="NORD", nom_normalise="nord", ordre=1, actif=True)
+    db.add(nord)
     db.commit()
 
     today = datetime.now()
@@ -66,7 +70,7 @@ def db_with_cultures(test_db):
         quantite=3.0,
         rang=1,
         unite="plants",
-        parcelle="NORD",
+        parcelle_id=nord.id,
         date=today - timedelta(days=27),
     ))
     # Salade dans parcelle NORD plantée il y a 50 jours (> seuil 45j végétatif)
@@ -77,7 +81,7 @@ def db_with_cultures(test_db):
         quantite=8.0,
         rang=1,
         unite="plants",
-        parcelle="NORD",
+        parcelle_id=nord.id,
         date=today - timedelta(days=50),
     ))
     # Basilic sans parcelle plantée il y a 8 jours
@@ -88,7 +92,7 @@ def db_with_cultures(test_db):
         quantite=20.0,
         rang=1,
         unite="plants",
-        parcelle=None,
+        parcelle_id=None,
         date=today - timedelta(days=8),
     ))
     db.commit()

--- a/utils/parcelles.py
+++ b/utils/parcelles.py
@@ -286,13 +286,14 @@ def rename_parcelle(
     if conflit is not None:
         raise ValueError(f"Ce nom est déjà utilisé par une autre parcelle : {conflit.nom!r}")
 
-    ancien_nom_stocke = parcelle.nom
+    ancien_nom = parcelle.nom
 
-    # Propagation sur evenements.parcelle (nom textuel)
+    # [migration_v12] la colonne evenements.parcelle n'existe plus :
+    # les événements sont liés via parcelle_id — compter suffit, pas besoin de propager
     nb_evenements = (
         db.query(Evenement)
-        .filter(Evenement.parcelle == ancien_nom_stocke)
-        .update({Evenement.parcelle: nouveau_nom}, synchronize_session="fetch")
+        .filter(Evenement.parcelle_id == parcelle.id)
+        .count()
     )
 
     # Mise à jour de la parcelle elle-même
@@ -303,8 +304,8 @@ def rename_parcelle(
     db.refresh(parcelle)
 
     log.info(
-        f"[US-006] Parcelle renommée : {ancien_nom_stocke!r} → {nouveau_nom!r} "
-        f"({nb_evenements} événements mis à jour)"
+        f"[US-006] Parcelle renommée : {ancien_nom!r} → {nouveau_nom!r} "
+        f"({nb_evenements} événements liés)"
     )
     return parcelle, nb_evenements
 
@@ -365,12 +366,13 @@ def calcul_occupation_parcelles(db: Session) -> Dict[Optional[str], list]:
         db.query(
             Evenement.culture,
             Evenement.variete,
-            Evenement.parcelle,
+            Parcelle.nom.label("parcelle_nom"),
             Evenement.quantite,
             Evenement.rang,
             Evenement.unite,
             Evenement.date,
         )
+        .outerjoin(Parcelle, Evenement.parcelle_id == Parcelle.id)
         .filter(Evenement.type_action == "plantation")
         .filter(Evenement.culture.in_(list(cultures_actives)))
         .order_by(Evenement.date)

--- a/utils/stock.py
+++ b/utils/stock.py
@@ -113,7 +113,17 @@ def calcul_stock_cultures(db: Session) -> Dict[str, StockCulture]:
     )
     pertes: Dict[str, float] = {c: (q or 0) for c, q in pertes_raw}
 
-    # ── 3. Récoltes par (culture, unite) ───────────────────────────────────
+    # ── 3. Récoltes par (culture, unite) — normalisées en grammes ──────────
+    _UNITE_TO_G = {"kg": 1000.0, "g": 1.0, "mg": 0.001}
+
+    def _to_g(val: float, unite: str) -> float:
+        return val * _UNITE_TO_G.get((unite or "").lower(), 1.0)
+
+    def _best_unite(total_g: float) -> tuple:
+        if total_g >= 1000:
+            return round(total_g / 1000, 2), "kg"
+        return round(total_g, 1), "g"
+
     recoltes_raw = (
         db.query(
             Evenement.culture,
@@ -126,13 +136,20 @@ def calcul_stock_cultures(db: Session) -> Dict[str, StockCulture]:
         .group_by(Evenement.culture, Evenement.unite)
         .all()
     )
-    recoltes: Dict[str, tuple] = {}  # culture → (nb, total, unite)
+    # Agréger en grammes pour éviter le mélange kg/g
+    recoltes_g: Dict[str, tuple] = {}  # culture → (nb, total_g)
     for culture, unite, nb, total in recoltes_raw:
-        existing = recoltes.get(culture)
-        if existing:
-            recoltes[culture] = (existing[0] + nb, existing[1] + (total or 0), unite or existing[2])
+        val_g = _to_g(total or 0.0, unite)
+        if culture in recoltes_g:
+            prev_nb, prev_g = recoltes_g[culture]
+            recoltes_g[culture] = (prev_nb + nb, prev_g + val_g)
         else:
-            recoltes[culture] = (nb, total or 0, unite or "")
+            recoltes_g[culture] = (nb, val_g)
+
+    recoltes: Dict[str, tuple] = {}  # culture → (nb, valeur_lisible, unite)
+    for culture, (nb, total_g) in recoltes_g.items():
+        val, unite_out = _best_unite(total_g)
+        recoltes[culture] = (nb, val, unite_out)
 
     # ── 4. Construction des objets StockCulture ─────────────────────────────
     result: Dict[str, StockCulture] = {}
@@ -394,31 +411,79 @@ def calcul_stock_par_variete(db: Session, culture: str) -> List[dict]:
                 "date_min": date_ev,
             }
 
-    # ── 6. Agrégation récoltes par variété ───────────────────────────────────
-    recoltes: Dict[Optional[str], dict] = {}
+    # ── 6. Agrégation récoltes par variété — en grammes pour normaliser ────────
+    _UNITE_TO_G_V = {"kg": 1000.0, "g": 1.0, "mg": 0.001}
+
+    recoltes_g: Dict[Optional[str], dict] = {}
     for variete, unite, qte, date_ev in recoltes_raw:
-        val = qte or 0
-        if variete in recoltes:
-            recoltes[variete]["nb"]    += 1
-            recoltes[variete]["total"] += val
+        val_g = (qte or 0) * _UNITE_TO_G_V.get((unite or "").lower(), 1.0)
+        if variete in recoltes_g:
+            recoltes_g[variete]["nb"]    += 1
+            recoltes_g[variete]["total"] += val_g
             if date_ev and (
-                recoltes[variete]["date_max"] is None
-                or date_ev > recoltes[variete]["date_max"]
+                recoltes_g[variete]["date_max"] is None
+                or date_ev > recoltes_g[variete]["date_max"]
             ):
-                recoltes[variete]["date_max"] = date_ev
+                recoltes_g[variete]["date_max"] = date_ev
         else:
-            recoltes[variete] = {
+            recoltes_g[variete] = {
                 "nb":       1,
-                "total":    val,
+                "total":    val_g,
                 "unite":    unite or "",
                 "date_max": date_ev,
             }
 
+    def _best_g(total_g: float) -> tuple:
+        if total_g >= 1000:
+            return round(total_g / 1000, 2), "kg"
+        return round(total_g, 1), "g"
+
+    recoltes: Dict[Optional[str], dict] = {}
+    for variete, d in recoltes_g.items():
+        val, unite_out = _best_g(d["total"])
+        recoltes[variete] = {
+            "nb":       d["nb"],
+            "total":    val,
+            "unite":    unite_out,
+            "date_max": d["date_max"],
+        }
+
     # ── 7. Construction de la liste de résultats ─────────────────────────────
     # [CA5] None regroupé comme "Variété non précisée"
+    # Les récoltes sans variété (None) sont fusionnées avec les variétés plantées
+    # si la culture n'a qu'une seule variété plantée, sinon listées séparément.
+    recoltes_sans_variete = recoltes.pop(None, None)
+    varietes_plantees = list(plantes.keys())
+    if recoltes_sans_variete:
+        if len(varietes_plantees) == 1:
+            # Une seule variété plantée → on rattache les récoltes sans variété à elle
+            vk = varietes_plantees[0]
+            if vk in recoltes:
+                recoltes[vk]["nb"]    += recoltes_sans_variete["nb"]
+                recoltes[vk]["total"] += recoltes_sans_variete["total"]
+                if recoltes_sans_variete["date_max"] and (
+                    recoltes[vk]["date_max"] is None
+                    or recoltes_sans_variete["date_max"] > recoltes[vk]["date_max"]
+                ):
+                    recoltes[vk]["date_max"] = recoltes_sans_variete["date_max"]
+                # Renormaliser après fusion
+                total_g = recoltes[vk]["total"] * _UNITE_TO_G_V.get(recoltes[vk]["unite"], 1.0)
+                val, unite_out = _best_g(total_g)
+                recoltes[vk]["total"] = val
+                recoltes[vk]["unite"] = unite_out
+            else:
+                recoltes[vk] = recoltes_sans_variete
+        else:
+            # Plusieurs variétés → garder "Variété non précisée" séparément (sans plantation)
+            recoltes[None] = recoltes_sans_variete
+
     result: List[dict] = []
-    for vkey in sorted(plantes.keys(), key=lambda v: ("" if v is None else v)):
-        p = plantes[vkey]
+    all_keys = sorted(
+        set(list(plantes.keys()) + ([None] if None in recoltes else [])),
+        key=lambda v: ("" if v is None else v)
+    )
+    for vkey in all_keys:
+        p = plantes.get(vkey, {"total": 0, "unite": "plants", "date_min": None})
         r = recoltes.get(vkey, {"nb": 0, "total": 0.0, "unite": "", "date_max": None})
         result.append({
             "variete":                  vkey if vkey is not None else "Variété non précisée",


### PR DESCRIPTION
## Résumé

- Suppression de la colonne `evenements.parcelle` (texte dénormalisé) suite à la migration v12 qui l'avait retirée de la base mais pas du code
- Ajout de `origine_graines_id` dans le modèle SQLAlchemy (colonne existante en base, absente du modèle)
- Restauration du fichier `migrations/migration_v12.sql` manquant
- Ajout de `CLAUDE.md` pour guider les futures sessions Claude Code

## Corrections détaillées

- **`database/models.py`** : supprime `parcelle` (colonne), ajoute `origine_graines_id`, `relationship parcelle_rel` + `@property parcelle` pour compatibilité lecture
- **`bot.py`** : supprime `parcelle=` dans les créations d'`Evenement`, ajoute `resolve_parcelle` dans `_parse_multi`, corrige les filtres via jointure `Parcelle`
- **`main.py`** : supprime `parcelle=` et `produit=` inexistants, ajoute `resolve_parcelle` + `parcelle_id`
- **`utils/parcelles.py`** : `rename_parcelle` sans propagation sur colonne supprimée, `calcul_occupation_parcelles` via jointure `Parcelle.nom`
- **`tests/`** : fixtures et assertions migrées vers `parcelle_id` (3 fichiers de tests)
- **`migrations/migration_v12.sql`** : recréation du fichier manquant, idempotent

## Plan de test

- [ ] `pytest tests/ -q` — 231+ tests passent
- [ ] `/start` dans Telegram ne génère plus d'erreur `UndefinedColumn`
- [ ] `plantation 10 pieds de salade parcelle nord` s'enregistre correctement
- [ ] `/plan` et `/parcelle lister` fonctionnent
- [ ] `.\update_dev.ps1` sur base vierge aboutit au schéma v12

🤖 Generated with [Claude Code](https://claude.com/claude-code)