### PR TITLE
fix: corriger ordre et visibilité des migrations au déploiement

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,9 +48,9 @@ jobs:
             set -euo pipefail
             cd /opt/potager
             set -a && source .env.prod && set +a
-            for migration in migrations/migration_v*.sql; do
+            for migration in \$(ls migrations/migration_v*.sql | sort -t v -k2 -n); do
               echo \"Applying \${migration}...\"
-              psql \"\${DATABASE_URL}\" -f \"\${migration}\" 2>/dev/null || true
+              psql \"\${DATABASE_URL}\" -v ON_ERROR_STOP=1 -f \"\${migration}\"
             done
           "
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -50,9 +50,9 @@ ssh "${DEPLOY_HOST}" "
   cd ${REMOTE_DIR}
   export APP_ENV=prod
   set -a && source .env.prod && set +a
-  for migration in migrations/migration_v*.sql; do
+  for migration in \$(ls migrations/migration_v*.sql | sort -t v -k2 -n); do
     echo \"    Applying \${migration}...\"
-    psql \"\${DATABASE_URL}\" -f \"\${migration}\" 2>/dev/null || true
+    psql \"\${DATABASE_URL}\" -v ON_ERROR_STOP=1 -f \"\${migration}\"
   done
 "
 


### PR DESCRIPTION
- Remplace le tri alphabétique (v10 avant v2) par un tri numérique sur le numéro de version via `sort -t v -k2 -n`
- Supprime `2>/dev/null || true` qui masquait silencieusement les erreurs psql
- Ajoute `-v ON_ERROR_STOP=1` pour stopper au premier problème détecté

Cause : migration_v12.sql non appliquée en prod car ses erreurs étaient ignorées et l'ordre d'exécution incorrect.

## Description

<!-- Décris brièvement ce que cette PR apporte -->

## Issues liées

<!-- Liste les issues fermées par cette PR (obligatoire) -->
closes #
fixes #

## Type de changement

- [ ] feat — nouvelle fonctionnalité
- [ ] fix — correction de bug
- [ ] chore — maintenance (renommage, refacto mineur, etc.)
- [ ] migration — modification base de données

## Checklist

- [ ] Les tests passent en local (`pytest`)
- [ ] Aucun secret hardcodé
- [ ] PATCH_NOTES.md mis à jour si nécessaire
