### PR TITLE
fix: rendre migration_v2 idempotente + suivi des migrations appliquées

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,9 +48,17 @@ jobs:
             set -euo pipefail
             cd /opt/potager
             set -a && source .env.prod && set +a
+            APPLIED_LOG=/opt/potager/.migrations_applied
+            touch \"\${APPLIED_LOG}\"
             for migration in \$(ls migrations/migration_v*.sql | sort -t v -k2 -n); do
-              echo \"Applying \${migration}...\"
+              name=\$(basename \"\${migration}\")
+              if grep -qF \"\${name}\" \"\${APPLIED_LOG}\"; then
+                echo \"  [-] \${name} (déjà appliquée)\"
+                continue
+              fi
+              echo \"  >>> Applying \${migration}...\"
               psql \"\${DATABASE_URL}\" -v ON_ERROR_STOP=1 -f \"\${migration}\"
+              echo \"\${name}\" >> \"\${APPLIED_LOG}\"
             done
           "
 

--- a/migrations/migration_v2.sql
+++ b/migrations/migration_v2.sql
@@ -9,8 +9,16 @@ ALTER TABLE evenements ADD COLUMN IF NOT EXISTS rang           VARCHAR;
 ALTER TABLE evenements ADD COLUMN IF NOT EXISTS traitement     VARCHAR;
 ALTER TABLE evenements ADD COLUMN IF NOT EXISTS texte_original VARCHAR;
 
--- Recopier 'produit' vers 'culture' pour les données existantes
-UPDATE evenements SET culture = produit WHERE culture IS NULL AND produit IS NOT NULL;
+-- Recopier 'produit' vers 'culture' pour les données existantes (si colonne encore présente)
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'evenements' AND column_name = 'produit'
+  ) THEN
+    UPDATE evenements SET culture = produit WHERE culture IS NULL AND produit IS NOT NULL;
+  END IF;
+END $$;
 
 -- Vérification : doit lister toutes les colonnes
 SELECT column_name, data_type


### PR DESCRIPTION
- migration_v2.sql : entoure le UPDATE produit→culture dans un DO $$ IF EXISTS pour ne pas crasher si la colonne a déjà été supprimée
- deploy.yml : ajoute un fichier .migrations_applied sur le serveur (comme update_dev.ps1) pour ne rejouer que les migrations non encore appliquées

## Description

<!-- Décris brièvement ce que cette PR apporte -->

## Issues liées

<!-- Liste les issues fermées par cette PR (obligatoire) -->
closes #
fixes #

## Type de changement

- [ ] feat — nouvelle fonctionnalité
- [ ] fix — correction de bug
- [ ] chore — maintenance (renommage, refacto mineur, etc.)
- [ ] migration — modification base de données

## Checklist

- [ ] Les tests passent en local (`pytest`)
- [ ] Aucun secret hardcodé
- [ ] PATCH_NOTES.md mis à jour si nécessaire
