### PR TITLE
fix(godet): corriger déduction stock semis — barquette consommée (nb_graines_semees)

### DIFF
--- a/tests/test_us016_017_018_godet_stock.py
+++ b/tests/test_us016_017_018_godet_stock.py
@@ -100,59 +100,70 @@ def test_us016_ca4_ratio_plants_sur_graines():
     assert parsed["nb_graines_semees"] == 30
 
 
-# ── US-017 CA1 ── calcul_semis() utilise nb_plants_godets
-def test_us017_ca1_calcul_semis_utilise_nb_plants_godets(db):
-    """CA1 — calcul_semis() déduit nb_plants_godets (pas nb_graines_semees) du stock."""
+# ── US-017 CA1 ── calcul_semis() déduit nb_graines_semees quand fourni
+def test_us017_ca1_calcul_semis_deduit_graines_barquette(db):
+    """CA1 — '5 plants sur 10 graines' consomme 10 graines du stock, pas 5."""
     session, pid = db
     _semis(session, pid, "courgette", variete="jaune", quantite=20)
-    # nb_plants_godets=10, nb_graines_semees=30 (barquette d'origine)
-    _godet(session, pid, "courgette", variete="jaune", nb_plants=10, nb_graines=30)
+    # 5 plants repiqués depuis une barquette de 10 graines → 10 graines consommées
+    _godet(session, pid, "courgette", variete="jaune", nb_plants=5, nb_graines=10)
 
     result = calcul_semis(session)
     courgette = result.get("courgette")
     assert courgette is not None
-    assert courgette["plants_en_godet"] == 10    # déduit nb_plants_godets
-    assert courgette["stock_residuel"] == 10     # 20 - 10 = 10
-    # S'assurer qu'on ne déduit PAS nb_graines_semees (30 != 10)
-    assert courgette["plants_en_godet"] != 30
+    assert courgette["plants_en_godet"] == 5     # plants repiqués affichés
+    assert courgette["stock_residuel"] == 10     # 20 - 10 (barquette) = 10
 
 
 # ── US-017 CA2 ── calcul_semis_par_culture() retourne stock_residuel par variété
 def test_us017_ca2_semis_par_culture_stock_residuel(db):
-    """CA2 — calcul_semis_par_culture() calcule le stock résiduel par variété."""
+    """CA2 — stock_residuel = total_seme - graines_barquette_consommees par variété."""
     session, pid = db
     _semis(session, pid, "courgette", variete="jaune", quantite=20)
     _semis(session, pid, "courgette", variete="ronde", quantite=15)
-    _godet(session, pid, "courgette", variete="jaune", nb_plants=10)
+    # 5 plants sur 10 graines → 10 graines consommées pour jaune
+    _godet(session, pid, "courgette", variete="jaune", nb_plants=5, nb_graines=10)
 
     result = calcul_semis_par_culture(session, "courgette")
     by_var = {r["variete"]: r for r in result}
 
-    assert by_var["jaune"]["plants_en_godet"] == 10
-    assert by_var["jaune"]["stock_residuel"] == 10     # 20 - 10
+    assert by_var["jaune"]["plants_en_godet"] == 5
+    assert by_var["jaune"]["stock_residuel"] == 10     # 20 - 10 (barquette)
     assert by_var["ronde"]["plants_en_godet"] == 0
     assert by_var["ronde"]["stock_residuel"] == 15     # 15 - 0
 
 
-# ── US-017 CA3 ── affichage total correct (total_seme - nb_plants_godets)
-def test_us017_ca3_total_correct_apres_deduction(db):
-    """CA3 — Le stock résiduel global culture est bien total_seme - plants_en_godet."""
+# ── US-017 CA2bis ── sans nb_graines_semees → fallback sur nb_plants_godets
+def test_us017_ca2bis_fallback_sur_plants_si_pas_de_graines(db):
+    """CA2bis — Sans nb_graines_semees, on déduit nb_plants_godets du stock."""
     session, pid = db
-    _semis(session, pid, "tomate", quantite=50)
-    _godet(session, pid, "tomate", nb_plants=50)
+    _semis(session, pid, "tomate", quantite=30)
+    _godet(session, pid, "tomate", nb_plants=8, nb_graines=None)  # pas de ratio fourni
 
     result = calcul_semis(session)
     tomate = result.get("tomate")
-    assert tomate["plants_en_godet"] == 50
-    assert tomate["stock_residuel"] == 0
+    assert tomate["plants_en_godet"] == 8
+    assert tomate["stock_residuel"] == 22     # 30 - 8
+
+
+# ── US-017 CA3 ── barquette entièrement consommée
+def test_us017_ca3_barquette_entierement_consommee(db):
+    """CA3 — Si barquette = semis total, stock_residuel = 0."""
+    session, pid = db
+    _semis(session, pid, "tomate", quantite=20)
+    _godet(session, pid, "tomate", nb_plants=15, nb_graines=20)  # barquette de 20
+
+    result = calcul_semis(session)
+    tomate = result.get("tomate")
+    assert tomate["stock_residuel"] == 0     # 20 - 20
 
 
 # ── US-017 CA4 ── stock résiduel jamais négatif
 def test_us017_ca4_stock_residuel_jamais_negatif(db):
-    """CA4 — Si plus de plants en godet que de semis, stock_residuel = 0 (pas négatif)."""
+    """CA4 — stock_residuel = 0 même si nb_graines_semees > total_seme."""
     session, pid = db
     _semis(session, pid, "courgette", variete="jaune", quantite=10)
-    _godet(session, pid, "courgette", variete="jaune", nb_plants=15)  # plus que semis
+    _godet(session, pid, "courgette", variete="jaune", nb_plants=5, nb_graines=15)
 
     result = calcul_semis_par_culture(session, "courgette")
     jaune = next(r for r in result if r["variete"] == "jaune")

--- a/tests/test_us_mise_en_godet.py
+++ b/tests/test_us_mise_en_godet.py
@@ -472,9 +472,9 @@ class TestCA10CalcSemisEnriched:
 
         semis = calcul_semis(test_db)
         assert "tomate" in semis
-        # [US-017] On déduit nb_plants_godets (24), pas nb_graines_semees (30)
+        # [US-017 corrigé] On déduit nb_graines_semees (30 = barquette consommée)
         assert semis["tomate"]["plants_en_godet"] == 24
-        assert semis["tomate"]["stock_residuel"] == max(0, 50 - 24)  # 26
+        assert semis["tomate"]["stock_residuel"] == max(0, 50 - 30)  # 20
 
     def test_ca10_graines_en_godet_zero_si_aucun_godet(self, test_db) -> None:
         """CA10 — graines_en_godet vaut 0 si aucune mise_en_godet pour cette culture."""

--- a/utils/stock.py
+++ b/utils/stock.py
@@ -244,28 +244,38 @@ def calcul_semis(db: Session) -> Dict[str, dict]:
     )
     unites: Dict[str, str] = {c: u for c, u in unites_raw}
 
-    # [US-017] Plants repiqués en godet par culture — on utilise nb_plants_godets
-    # (et non nb_graines_semees qui représente la barquette d'origine)
-    godets_raw = (
-        db.query(Evenement.culture, func.sum(Evenement.nb_plants_godets))
+    # Graines consommées par culture : nb_graines_semees si fourni, sinon nb_plants_godets.
+    # Règle métier : "5 plants sur 10 graines" → 10 graines consommées (toute la barquette),
+    # pas 5. Les graines non germées sont perdues, elles quittent quand même le stock.
+    godets_brut = (
+        db.query(
+            Evenement.culture,
+            Evenement.nb_graines_semees,
+            Evenement.nb_plants_godets,
+        )
         .filter(Evenement.type_action == "mise_en_godet")
         .filter(Evenement.culture.isnot(None))
-        .group_by(Evenement.culture)
         .all()
     )
-    plants_en_godet: Dict[str, int] = {c: (int(q) if q else 0) for c, q in godets_raw}
+    graines_consommees: Dict[str, int] = {}
+    plants_en_godet: Dict[str, int] = {}
+    for culture, nb_g, nb_p in godets_brut:
+        consommees = int(nb_g) if nb_g else (int(nb_p) if nb_p else 0)
+        plants     = int(nb_p) if nb_p else 0
+        graines_consommees[culture] = graines_consommees.get(culture, 0) + consommees
+        plants_en_godet[culture]    = plants_en_godet.get(culture, 0) + plants
 
     result: Dict[str, dict] = {}
     for culture, nb, total in semis_raw:
         total_seme = total or 0
-        en_godet   = plants_en_godet.get(culture, 0)
+        consommees = graines_consommees.get(culture, 0)
         result[culture] = {
-            "nb_semis":       nb,
-            "total_seme":     total_seme,
-            "unite":          unites.get(culture, "graines"),
-            "type_organe":    get_type_organe(db, culture),
-            "plants_en_godet": en_godet,
-            "stock_residuel": max(0, int(total_seme) - en_godet),
+            "nb_semis":        nb,
+            "total_seme":      total_seme,
+            "unite":           unites.get(culture, "graines"),
+            "type_organe":     get_type_organe(db, culture),
+            "plants_en_godet": plants_en_godet.get(culture, 0),
+            "stock_residuel":  max(0, int(total_seme) - consommees),
         }
     return dict(sorted(result.items()))
 
@@ -294,17 +304,25 @@ def calcul_semis_par_culture(db: Session, culture: str) -> List[dict]:
     if not semis_raw:
         return []
 
-    # [US-017] Plants repiqués en godet par variété pour cette culture
-    godets_raw = (
-        db.query(Evenement.variete, func.sum(Evenement.nb_plants_godets))
+    # Graines consommées par variété : nb_graines_semees si fourni, sinon nb_plants_godets.
+    # "5 plants sur 10 graines" → 10 graines déduites du stock (toute la barquette consommée).
+    godets_brut_var = (
+        db.query(
+            Evenement.variete,
+            Evenement.nb_graines_semees,
+            Evenement.nb_plants_godets,
+        )
         .filter(func.lower(Evenement.culture) == culture_lower)
         .filter(Evenement.type_action == "mise_en_godet")
-        .group_by(Evenement.variete)
         .all()
     )
-    plants_en_godet_var: Dict[Optional[str], int] = {
-        v: (int(q) if q else 0) for v, q in godets_raw
-    }
+    graines_consommees_var: Dict[Optional[str], int] = {}
+    plants_en_godet_var: Dict[Optional[str], int] = {}
+    for variete, nb_g, nb_p in godets_brut_var:
+        consommees = int(nb_g) if nb_g else (int(nb_p) if nb_p else 0)
+        plants     = int(nb_p) if nb_p else 0
+        graines_consommees_var[variete] = graines_consommees_var.get(variete, 0) + consommees
+        plants_en_godet_var[variete]    = plants_en_godet_var.get(variete, 0) + plants
 
     agregat: Dict[Optional[str], dict] = {}
     for variete, unite, qte, date_ev in semis_raw:
@@ -325,7 +343,8 @@ def calcul_semis_par_culture(db: Session, culture: str) -> List[dict]:
 
     result = []
     for variete, d in sorted(agregat.items(), key=lambda x: ("" if x[0] is None else x[0])):
-        en_godet = plants_en_godet_var.get(variete, 0)
+        en_godet   = plants_en_godet_var.get(variete, 0)
+        consommees = graines_consommees_var.get(variete, 0)
         result.append({
             "variete":            variete,
             "nb_semis":           d["nb_semis"],
@@ -333,7 +352,7 @@ def calcul_semis_par_culture(db: Session, culture: str) -> List[dict]:
             "unite":              d["unite"],
             "date_premier_semis": d["date_premier_semis"],
             "plants_en_godet":    en_godet,
-            "stock_residuel":     max(0, int(d["total_seme"]) - en_godet),
+            "stock_residuel":     max(0, int(d["total_seme"]) - consommees),
         })
     return result
 


### PR DESCRIPTION
## Problème

Bug de logique métier dans le calcul du stock résiduel de semis après une mise en godet.

**Scénario :** Stock semis = 20 graines · 5 déjà en godet · **15 restantes**
Nouvelle mise en godet : "5 courgettes jaune sur 10 graines"

| | Avant correction | Après correction |
|---|---|---|
| Résultat affiché | 10 en godet · **10 restantes** | 10 en godet · **5 restantes** |
| Calcul | 20 - 5 - 5 = 10 | 20 - 5 - 10 = 5 |

## Règle métier correcte

"5 plants sur 10 graines" signifie :
- Une barquette de **10 graines** a été semée
- **5 ont germé** et sont repiquées en godet
- Les 5 autres sont perdues (mal germées, trop petites)
- La barquette entière (**10 graines**) est consommée du stock de semis

## Correction

**`calcul_semis()` et `calcul_semis_par_culture()` dans `utils/stock.py` :**
- Si `nb_graines_semees` est renseigné → déduire `nb_graines_semees` (barquette consommée)
- Si `nb_graines_semees` est absent → déduire `nb_plants_godets` par défaut (approximation)

## Tests

- 40 tests verts (4 préexistants SQLite inchangés)
- Nouveaux cas : CA2bis (fallback sans nb_graines_semees), CA3 (barquette entièrement consommée), CA4 (jamais négatif)

🤖 Generated with [Claude Code](https://claude.com/claude-code)