### PR TITLE
feat(api): endpoint GET /meteo/history + fetch_meteo_history (v3.10.0)

### DIFF
--- a/main.py
+++ b/main.py
@@ -721,6 +721,44 @@ def get_godet_detail(culture: str = Query(...), variete: str = Query(default=Non
         db.close()
 
 
+@app.get("/meteo/history")
+def meteo_history(
+    days    : int   = Query(default=30, ge=7, le=365, description="Nombre de jours d'historique"),
+    lat     : float = Query(default=None, description="Latitude GPS (défaut : potager configuré)"),
+    lon     : float = Query(default=None, description="Longitude GPS (défaut : potager configuré)"),
+    timezone: str   = Query(default=None, description="Fuseau IANA (défaut : Europe/Paris)"),
+):
+    """
+    Historique météo journalier (températures min/max + précipitations) depuis Open-Meteo Archive.
+    Gratuit, sans authentification, zéro token Groq.
+
+    Paramètres optionnels lat/lon permettent d'interroger n'importe quel potager.
+    Retourne : { jours: [...], meta: { lat, lon, timezone, days, start_date, end_date } }
+    """
+    from utils.meteo import fetch_meteo_history, METEO_LATITUDE, METEO_LONGITUDE, METEO_TIMEZONE
+
+    eff_lat = lat      if lat      is not None else METEO_LATITUDE
+    eff_lon = lon      if lon      is not None else METEO_LONGITUDE
+    eff_tz  = timezone if timezone is not None else METEO_TIMEZONE
+
+    jours = fetch_meteo_history(lat=eff_lat, lon=eff_lon, days=days, timezone=eff_tz)
+
+    if jours is None:
+        raise HTTPException(status_code=502, detail="Impossible de récupérer les données Open-Meteo Archive")
+
+    return {
+        "jours": jours,
+        "meta": {
+            "lat"       : eff_lat,
+            "lon"       : eff_lon,
+            "timezone"  : eff_tz,
+            "days"      : days,
+            "start_date": jours[0]["date"]  if jours else None,
+            "end_date"  : jours[-1]["date"] if jours else None,
+        },
+    }
+
+
 @app.get("/historique")
 def historique(
     limit     : int  = Query(default=20, le=100),

--- a/utils/meteo.py
+++ b/utils/meteo.py
@@ -31,7 +31,8 @@ METEO_LONGITUDE = 2.2038296967715305
 METEO_TIMEZONE  = "Europe/Paris"
 
 # ── URL Open-Meteo ─────────────────────────────────────────────────────────────
-OPEN_METEO_URL = "https://api.open-meteo.com/v1/forecast"
+OPEN_METEO_URL         = "https://api.open-meteo.com/v1/forecast"
+OPEN_METEO_ARCHIVE_URL = "https://archive-api.open-meteo.com/v1/archive"
 
 # ── Codes météo WMO → label potager ───────────────────────────────────────────
 # https://open-meteo.com/en/docs#weathervariables
@@ -232,6 +233,76 @@ def format_meteo_commentaire(m: dict) -> str:
         f"☀ {m['lever_soleil']}→{m['coucher_soleil']} · "
         f"{m['conseil']}"
     )
+
+
+def fetch_meteo_history(
+    lat: float = METEO_LATITUDE,
+    lon: float = METEO_LONGITUDE,
+    days: int = 30,
+    timezone: str = METEO_TIMEZONE,
+) -> list[dict] | None:
+    """
+    Interroge Open-Meteo Archive pour l'historique météo journalier.
+
+    Args:
+        lat      : latitude GPS (défaut : potager configuré)
+        lon      : longitude GPS (défaut : potager configuré)
+        days     : nombre de jours d'historique (7–365)
+        timezone : fuseau IANA (défaut : Europe/Paris)
+
+    Retourne une liste de dicts triés par date croissante :
+        [{ date, temp_max, temp_min, precipitations, wmo_code, emoji, label }, ...]
+    Retourne None en cas d'erreur réseau ou de parsing.
+    """
+    from datetime import timedelta
+
+    today      = date.today()
+    end_date   = today - timedelta(days=1)          # archive n'a pas les données du jour
+    start_date = end_date - timedelta(days=days - 1)
+
+    params = {
+        "latitude"  : lat,
+        "longitude" : lon,
+        "start_date": start_date.isoformat(),
+        "end_date"  : end_date.isoformat(),
+        "daily"     : [
+            "temperature_2m_max",
+            "temperature_2m_min",
+            "precipitation_sum",
+            "weathercode",
+        ],
+        "timezone"  : timezone,
+    }
+
+    try:
+        resp = requests.get(OPEN_METEO_ARCHIVE_URL, params=params, timeout=10)
+        resp.raise_for_status()
+        raw = resp.json()
+    except requests.RequestException as e:
+        log.error(f"❌ MÉTÉO HISTORIQUE  : {e}")
+        return None
+
+    try:
+        daily  = raw["daily"]
+        times  = daily["time"]
+        result = []
+        for i, t in enumerate(times):
+            wmo         = daily["weathercode"][i]
+            emoji, label = _wmo_label(wmo)
+            result.append({
+                "date"          : t,
+                "temp_max"      : daily["temperature_2m_max"][i],
+                "temp_min"      : daily["temperature_2m_min"][i],
+                "precipitations": daily["precipitation_sum"][i] or 0.0,
+                "wmo_code"      : wmo,
+                "emoji"         : emoji,
+                "label"         : label,
+            })
+        log.info(f"🌤️  MÉTÉO HISTORIQUE : {len(result)} jours ({start_date} → {end_date})")
+        return result
+    except (KeyError, IndexError, TypeError) as e:
+        log.error(f"❌ MÉTÉO HISTORIQUE PARSE : {e}")
+        return None
 
 
 def save_meteo_observation(db: Session) -> dict | None:


### PR DESCRIPTION
- Ajoute GET /meteo/history?days=N (7–365) dans main.py — retourne l'historique météo journalier depuis Open-Meteo Archive (temp_max, temp_min, precipitations)
- Ajoute fetch_meteo_history() dans utils/meteo.py + OPEN_METEO_ARCHIVE_URL
- Gratuit, sans authentification, zéro token Groq

## Description

<!-- Décris brièvement ce que cette PR apporte -->

## Issues liées

<!-- Liste les issues fermées par cette PR (obligatoire) -->
closes #
fixes #

## Type de changement

- [ ] feat — nouvelle fonctionnalité
- [ ] fix — correction de bug
- [ ] chore — maintenance (renommage, refacto mineur, etc.)
- [ ] migration — modification base de données

## Checklist

- [ ] Les tests passent en local (`pytest`)
- [ ] Aucun secret hardcodé
- [ ] PATCH_NOTES.md mis à jour si nécessaire
