### PR TITLE
fix: ajoute l'action protection au prompt Groq de parsing

### DIFF
--- a/llm/groq_client.py
+++ b/llm/groq_client.py
@@ -92,7 +92,7 @@ Si une information n'est pas mentionnée, mets null. Ne jamais inventer.
 
 Champs à extraire :
 {{
-  "action"           : string,   // recolte | semis | repiquage | arrosage | fertilisation | traitement | desherbage | taille | paillage | observation | plantation | tuteurage | perte | mise_en_godet
+  "action"           : string,   // recolte | semis | repiquage | arrosage | fertilisation | traitement | desherbage | taille | paillage | protection | observation | plantation | tuteurage | perte | mise_en_godet
   "culture"          : string,   // légume au singulier minuscule ("tomates" → "tomate")
   "variete"          : string,   // variété ou couleur ("rouge", "nantaise"...)
   "quantite"         : number,   // quantité numérique (PAR RANG si rang mentionné)
@@ -126,6 +126,12 @@ Exemples :
 
 "traitement purin d'ortie sur les courgettes hier"
 → {{"action":"traitement","culture":"courgette","quantite":null,"unite":null,"date":"{yesterday}","parcelle":null,"rang":null,"duree_minutes":null,"traitement":"purin d ortie","variete":null,"commentaire":null}}
+
+"Mise d'un voile sur parcelle courge"
+→ {{"action":"protection","culture":"courge","quantite":null,"unite":null,"date":null,"parcelle":"courge","rang":null,"duree_minutes":null,"traitement":null,"variete":null,"commentaire":null}}
+
+"posé un filet anti-insectes sur les choux"
+→ {{"action":"protection","culture":"chou","quantite":null,"unite":null,"date":null,"parcelle":null,"rang":null,"duree_minutes":null,"traitement":null,"variete":null,"commentaire":null}}
 
 "semé des carottes nantaises parcelle est"
 → {{"action":"semis","culture":"carotte","quantite":null,"unite":null,"date":null,"parcelle":"est","rang":null,"duree_minutes":null,"traitement":null,"variete":"nantaise","commentaire":null}}

--- a/tests/test_groq.py
+++ b/tests/test_groq.py
@@ -1,10 +1,33 @@
 import pytest
 from unittest.mock import patch, MagicMock
-from llm.groq_client import parse_commande, extract_intent, repondre_question
+from llm.groq_client import parse_commande, extract_intent, repondre_question, PARSE_PROMPT
 
 
 class TestParseCommande:
     """Tests pour parse_commande (parsing avec Groq)."""
+
+    def test_parse_prompt_lists_protection_action(self):
+        """[Regression] 'protection' (voile/filet/cloche/tunnel) doit rester
+        dans l'enum du PARSE_PROMPT, sinon Groq la confond avec 'paillage'."""
+        assert "protection" in PARSE_PROMPT
+        assert "voile" in PARSE_PROMPT
+
+    @patch('llm.groq_client._client')
+    def test_parse_protection_voile(self, mock_client):
+        """Test parsing d'une phrase de protection (voile anti-gel)."""
+        mock_response = MagicMock()
+        mock_response.choices[0].message.content = '''{
+            "action": "protection",
+            "culture": "courge",
+            "parcelle": "courge"
+        }'''
+        mock_client.chat.completions.create.return_value = mock_response
+
+        result = parse_commande("Mise d'un voile sur parcelle courge")
+
+        assert len(result) == 1
+        assert result[0]['action'] == 'protection'
+        assert result[0]['culture'] == 'courge'
 
     @patch('llm.groq_client._client')
     def test_parse_perte(self, mock_client):


### PR DESCRIPTION
L'action canonique 'protection' (voile, filet, cloche, tunnel) existe
dans utils/actions.py mais était absente de l'enum du PARSE_PROMPT
envoyé à Groq. Le LLM confondait donc "mise d'un voile" avec
'paillage', le mot-clé le plus proche qu'il connaissait.