### PR TITLE
test(llm): basculer sur gpt-oss-120b suite dépréciation Llama 3.3

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,10 +47,11 @@ jobs:
           ssh ${{ secrets.SCALEWAY_USER }}@${{ secrets.SCALEWAY_HOST }} "
             set -euo pipefail
             cd /opt/potager
-            if [ ! -x venv/bin/python ]; then
+            if [ ! -x venv/bin/python ] || [ ! -x venv/bin/pip ]; then
               echo 'Création du virtualenv...'
               rm -rf venv
-              python3 -m venv venv
+              python3 -m venv venv --without-pip
+              venv/bin/python -m ensurepip --upgrade
             fi
             venv/bin/pip install --quiet --upgrade pip
             venv/bin/pip install --quiet -r requirements.txt

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,17 +43,58 @@ pytest tests/
 pytest tests/test_us006_renommer_parcelle.py   # single test file
 pytest tests/ -k "test_name"                   # single test by name
 
-# Start Telegram bot
-python bot.py
-
-# Start FastAPI server (http://localhost:8000)
-uvicorn main:app --host 0.0.0.0 --port 8000
-# NB: main.py n'a pas de bloc __main__ — `python main.py` ne lance rien.
-
 # Apply latest database migration
 psql -d potager -f migrations/migration_v12.sql
+```
 
-# Redéployer l'environnement dev local (pull + deps + migrations)
+### Lancer le bot Telegram et l'API en local (PowerShell, Windows)
+
+Le shell par défaut est PowerShell, pas bash — `VAR=val cmd` ne fonctionne pas, et
+`uvicorn`/`python` doivent venir du venv du projet (`.venv/`), pas du PATH global.
+
+```powershell
+cd "C:\Users\eremy\OneDrive - SQLI\Documents\GitHub\assistant-potager"
+.\.venv\Scripts\Activate.ps1          # active le venv pour la session courante
+$env:APP_ENV = "dev"                  # reste actif pour tout le terminal, une seule fois
+
+# Bot Telegram — pas de --reload possible, il faut arrêter (Ctrl+C) et relancer
+# manuellement à chaque modification de bot.py / groq_client.py / config.py
+python bot.py
+
+# API FastAPI (http://localhost:8000) — sert aussi le frontend buildé (frontend/dist)
+# --reload recharge automatiquement à chaque modification de fichier Python
+uvicorn main:app --host 0.0.0.0 --port 8000 --reload
+# NB: main.py n'a pas de bloc __main__ — `python main.py` ne lance rien, il faut passer par uvicorn.
+
+# Si Activate.ps1 est bloqué par la politique d'exécution PowerShell, contourner via :
+.\.venv\Scripts\python.exe -m uvicorn main:app --host 0.0.0.0 --port 8000 --reload
+```
+
+### Mettre à jour le frontend si l'interface change
+
+Le dashboard React (`frontend/`, Vite) peut tourner de deux façons :
+
+```powershell
+# Mode dev — hot reload instantané, pointe sur l'API via frontend/.env.local (VITE_API_URL)
+cd frontend
+npm install        # une seule fois / après changement de dépendances
+npm run dev        # http://localhost:3000
+
+# Mode "comme en prod" — l'API FastAPI sert le build statique
+cd frontend
+npm run build       # génère frontend/dist
+# puis (re)démarrer l'API pour qu'elle serve le nouveau build :
+cd ..
+uvicorn main:app --host 0.0.0.0 --port 8000 --reload
+```
+
+`main.py` sert `frontend/dist` en priorité (fallback sur `static/` si le build React est absent) —
+toute modification de l'UI nécessite un `npm run build` avant de se refléter via l'API,
+le mode `npm run dev` (port 3000) suffit pour itérer rapidement sans rebuild.
+
+### Redéployer l'environnement dev local (pull + deps + migrations)
+
+```powershell
 .\update_dev.ps1
 .\update_dev.ps1 -SkipPull   # depuis un hook git
 .\update_dev.ps1 -Force      # tout rejouer

--- a/config.py
+++ b/config.py
@@ -8,5 +8,11 @@ load_dotenv(f".env.{_env}", override=True)
 GROQ_API_KEY       = os.environ["GROQ_API_KEY"]
 TELEGRAM_BOT_TOKEN = os.environ["TELEGRAM_BOT_TOKEN"]
 DATABASE_URL       = os.environ["DATABASE_URL"]
-GROQ_MODEL         = "llama-3.3-70b-versatile"
+GROQ_MODEL         = "openai/gpt-oss-120b"
 GROQ_WHISPER_MODEL = "whisper-large-v3-turbo"
+
+# Niveau de raisonnement Groq ("low" | "medium" | "high" | None).
+# Uniquement supporté par les modèles reasoning (ex: gpt-oss-120b, qwen3.6-27b).
+# Mettre à None pour les modèles non-reasoning (ex: llama-3.3-70b-versatile),
+# sinon l'API Groq renvoie une erreur 400 "reasoning_effort is not supported".
+GROQ_REASONING_EFFORT = "low"

--- a/llm/groq_client.py
+++ b/llm/groq_client.py
@@ -14,9 +14,13 @@ import re
 import tempfile
 from datetime import date, timedelta
 from groq import Groq
-from config import GROQ_API_KEY, GROQ_MODEL, GROQ_WHISPER_MODEL
+from config import GROQ_API_KEY, GROQ_MODEL, GROQ_WHISPER_MODEL, GROQ_REASONING_EFFORT
 
 _client = Groq(api_key=GROQ_API_KEY)
+
+# Passé aux appels chat.completions.create() — vide pour les modèles non-reasoning
+# (ex: llama-3.3-70b-versatile), où l'API Groq rejette ce paramètre.
+_REASONING_KWARGS = {"reasoning_effort": GROQ_REASONING_EFFORT} if GROQ_REASONING_EFFORT else {}
 
 # ── Date du jour injectée dans le prompt ──────────────────────────────────────
 def _today_context() -> str:
@@ -76,7 +80,8 @@ def extract_intent(question: str) -> dict:
         ],
         temperature=0.0,
         max_tokens=128,
-        stream=False
+        stream=False,
+        **_REASONING_KWARGS
     )
 
     raw = chat.choices[0].message.content.strip()
@@ -203,7 +208,8 @@ def parse_commande(texte: str) -> list[dict]:
         ],
         temperature=0.0,
         max_tokens=1024,
-        stream=False
+        stream=False,
+        **_REASONING_KWARGS
     )
     raw = chat.choices[0].message.content.strip()
 
@@ -276,7 +282,8 @@ def repondre_question(question: str, contexte_json: str) -> str:
         ],
         temperature=0.0,
         max_tokens=200,
-        stream=False
+        stream=False,
+        **_REASONING_KWARGS
     )
     return chat.choices[0].message.content.strip()
 
@@ -463,6 +470,7 @@ def parse_message(texte: str) -> dict:
             temperature=0.0,
             max_tokens=1024,
             stream=False,
+            **_REASONING_KWARGS
         )
         raw = chat.choices[0].message.content.strip()
         if raw.startswith("```"):
@@ -512,8 +520,9 @@ def classify_intent_pwa(texte: str) -> str:
                 {"role": "user",   "content": texte},
             ],
             temperature=0.0,
-            max_tokens=8,
+            max_tokens=100,
             stream=False,
+            **_REASONING_KWARGS
         )
         result = chat.choices[0].message.content.strip().upper()
         return "INTERROGER" if "INTERROGER" in result else "ACTION"


### PR DESCRIPTION
## Contexte

Groq a annoncé la dépréciation de `llama-3.3-70b-versatile` (décommission le 16/08/2026, tier free/developer). `gpt-oss-120b` est le remplacement recommandé par Groq.

## Changements

- `config.py` : `GROQ_MODEL` → `openai/gpt-oss-120b`, nouvelle constante `GROQ_REASONING_EFFORT` (externalise le niveau de raisonnement, `None` pour les modèles non-reasoning type Llama 3.3)
- `llm/groq_client.py` : `reasoning_effort` appliqué conditionnellement sur les 5 appels Groq via `_REASONING_KWARGS`
  - Bug découvert en testant : `gpt-oss-120b` génère un raisonnement caché qui consommait le budget `max_tokens`, tronquant le JSON attendu → fallback silencieux "Je n'ai pas compris la question"
  - `classify_intent_pwa` : `max_tokens` remonté de 8 à 100 (le raisonnement, même réduit, dépasse 8 tokens et faisait mal classifier `INTERROGER` en `ACTION`)
- `CLAUDE.md` : commandes de lancement bot/API/frontend corrigées pour PowerShell + venv du projet

## Test plan

- [x] Simulation directe `extract_intent_query` + `query_agent_answer` sur plusieurs formulations de questions (`/ask`)
- [x] Simulation directe `classify_intent_pwa` (ACTION vs INTERROGER) sur plusieurs phrases
- [ ] Test bot Telegram complet en conditions réelles (vocal + texte) sur `dev`
- [ ] Vérifier `repondre_question` (max_tokens=200) sur des réponses plus longues
- [ ] Confirmer que `openai/gpt-oss-120b` est bien coché dans "Allowed Models" sur la console Groq de l'organisation

🤖 Generated with [Claude Code](https://claude.com/claude-code)