### PR TITLE
fix(pepiniere): rendre visibles les semis sans localisation pleine terre

### DIFF
--- a/frontend/src/views/Pepiniere.jsx
+++ b/frontend/src/views/Pepiniere.jsx
@@ -67,14 +67,23 @@ function ArcCounter({ total, restants }) {
 // ── Carte culture ─────────────────────────────────────────────────────────────
 
 function CultureCard({ g, epuise, onClick }) {
+  const enGermination = g.statut === 'en_germination'
   const stock  = g.stock_residuel_godet ?? 0
   const total  = g.nb_plants_godets    ?? 0
   const tm     = tauxMeta(g.taux_reussite)
-  const accent = stockAccentVar(stock, total)
+  const accent = enGermination ? 'var(--g-mid)' : stockAccentVar(stock, total)
 
-  const comment = epuise
-    ? `${total} plants entièrement plantés — lot clôturé.`
-    : `${total} plants en godet · ${g.nb_plantes ?? 0} planté${(g.nb_plantes ?? 0) > 1 ? 's' : ''} · ${stock} en attente de mise en place.`
+  let comment
+  if (enGermination) {
+    comment = `${g.graines_en_germination} ${g.unite_germination || 'graines'} semées, pas encore repiquées en godet.`
+  } else if (epuise) {
+    comment = `${total} plants entièrement plantés — lot clôturé.`
+  } else {
+    comment = `${total} plants en godet · ${g.nb_plantes ?? 0} planté${(g.nb_plantes ?? 0) > 1 ? 's' : ''} · ${stock} en attente de mise en place.`
+    if (g.graines_en_germination > 0) {
+      comment += ` (+${g.graines_en_germination} ${g.unite_germination || 'graines'} en germination)`
+    }
+  }
 
   return (
     <button
@@ -102,12 +111,14 @@ function CultureCard({ g, epuise, onClick }) {
               )}
             </div>
 
-            {/* Badge taux */}
+            {/* Badge taux / germination */}
             <span
               className="self-start text-[12px] font-semibold rounded-lg px-2 py-0.5"
-              style={{ color: tm.textVar, background: tm.bgVar }}
+              style={enGermination
+                ? { color: 'var(--g-mid)', background: 'var(--g-brd)' }
+                : { color: tm.textVar, background: tm.bgVar }}
             >
-              {tm.label}
+              {enGermination ? '🌱 En germination' : tm.label}
             </span>
 
             {/* Badge ventes */}
@@ -121,7 +132,14 @@ function CultureCard({ g, epuise, onClick }) {
             )}
           </div>
 
-          <ArcCounter total={total} restants={stock} />
+          {enGermination ? (
+            <div style={{ width: 48, height: 48, flexShrink: 0, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center' }}>
+              <span style={{ fontSize: 14, fontWeight: 800, color: 'var(--g-mid)', lineHeight: 1 }}>{g.graines_en_germination}</span>
+              <span style={{ fontSize: 8, color: 'var(--g-sec)', lineHeight: 1.4 }}>{g.unite_germination || 'graines'}</span>
+            </div>
+          ) : (
+            <ArcCounter total={total} restants={stock} />
+          )}
         </div>
 
         {/* Zone commentaire */}
@@ -234,7 +252,7 @@ function DetailSheet({ godet, onClose }) {
                         Semis <span className="font-normal" style={{ color: 'var(--g-sec)' }}>#{row.data.id}</span>
                       </p>
                       <p className="text-sm" style={{ color: 'var(--g-sec)' }}>
-                        {row.data.nb_graines} graine{row.data.nb_graines > 1 ? 's' : ''}
+                        {row.data.nb_graines} {row.data.unite || 'graines'}
                         {row.data.parcelle && <span style={{ color: 'var(--g-mid)' }}> · {row.data.parcelle}</span>}
                       </p>
                       <p className="text-[12px] mt-0.5" style={{ color: 'var(--g-sec)' }}>{fmt(row.data.date)}</p>

--- a/frontend/src/views/Stocks.jsx
+++ b/frontend/src/views/Stocks.jsx
@@ -1,6 +1,5 @@
 import { useState, useEffect } from 'react'
 import { Leaf, Sprout, ShoppingBag } from 'lucide-react'
-import { BarChart, Bar, XAxis, YAxis, Tooltip, Legend, ResponsiveContainer } from 'recharts'
 import { api } from '../lib/api.js'
 import { useDateRef } from '../context/AppContext.jsx'
 import DateRefPicker from '../components/DateRefPicker.jsx'
@@ -15,6 +14,7 @@ const ORIGINE_CONFIG = {
   'pépinière':          { label: 'Pépinière',         bg: 'var(--g-acc-dim)', text: 'var(--g-acc)' },
   'pied_acheté':        { label: 'Pied acheté',        bg: 'var(--g-amb-dim)', text: 'var(--g-amb)' },
   'semis_pleine_terre': { label: 'Semis pleine terre', bg: 'var(--g-brd)',     text: 'var(--g-mid)' },
+  'non_localisé':       { label: 'Non localisé',       bg: 'var(--g-brd)',     text: 'var(--g-sec)' },
 }
 
 function OrigineBadge({ origine }) {
@@ -64,11 +64,14 @@ function CultureRow({ c }) {
 // ── Ligne semis pleine terre ──────────────────────────────────────────────────
 
 function SemisRow({ s }) {
+  // [fix visibilité semis sans parcelle] Un semis dont toutes les parcelles
+  // valent "Non localisé" n'est pas vraiment "pleine terre" — badge dédié.
+  const nonLocalise = (s.parcelles || []).every(p => p === 'Non localisé')
   return (
     <div className="flex items-center gap-2 py-2.5 border-b border-g-brd last:border-0">
       <div className="flex-1 min-w-0 flex items-center gap-2 flex-wrap">
         <span className="text-base font-medium capitalize" style={{ color: 'var(--g-pri)' }}>{s.culture}</span>
-        <OrigineBadge origine="semis_pleine_terre" />
+        <OrigineBadge origine={nonLocalise ? 'non_localisé' : 'semis_pleine_terre'} />
       </div>
       <div className="text-right shrink-0">
         <p className="text-base font-semibold" style={{ color: 'var(--g-pri)' }}>
@@ -129,39 +132,6 @@ function Section({ icon, title, count, titleColor, children }) {
         <span className="shrink-0">Stock</span>
       </div>
       {children}
-    </div>
-  )
-}
-
-// ── Graphe comparatif ─────────────────────────────────────────────────────────
-
-function Chart({ cultures }) {
-  const data = cultures.slice(0, 10).map(c => ({
-    name:    c.culture.length > 7 ? c.culture.slice(0, 7) + '…' : c.culture,
-    planté:  c.plants_plantes || 0,
-    perdu:   c.plants_perdus  || 0,
-    récolté: c.type_organe === 'reproducteur' ? (c.nb_recoltes || 0) : 0,
-  }))
-
-  if (!data.length) return null
-
-  return (
-    <div className="bg-g-card border border-g-brd rounded-2xl p-3.5 mb-3">
-      <p className="text-sm font-medium mb-3" style={{ color: 'var(--g-sec)' }}>
-        Comparatif semis / récolte / perte
-        {cultures.length > 10 && <span className="text-[12px] ml-1" style={{ color: 'var(--g-sec)' }}>(10 premières)</span>}
-      </p>
-      <ResponsiveContainer width="100%" height={160}>
-        <BarChart data={data} margin={{ top: 0, right: 0, left: -20, bottom: 0 }}>
-          <XAxis dataKey="name" tick={{ fontSize: 10 }} />
-          <YAxis tick={{ fontSize: 10 }} />
-          <Tooltip contentStyle={{ fontSize: 12, borderRadius: 10 }} cursor={{ fill: 'var(--g-acc-dim)' }} />
-          <Legend iconSize={8} wrapperStyle={{ fontSize: 11 }} />
-          <Bar dataKey="planté"  fill="var(--g-acc)" radius={[3, 3, 0, 0]} />
-          <Bar dataKey="récolté" fill="var(--g-mid)" radius={[3, 3, 0, 0]} />
-          <Bar dataKey="perdu"   fill="var(--g-red)" radius={[3, 3, 0, 0]} />
-        </BarChart>
-      </ResponsiveContainer>
     </div>
   )
 }
@@ -259,9 +229,6 @@ export default function Stocks({ refresh }) {
       {(filteredStocks.length === 0 && filteredSemis.length === 0 && filteredGodets.length === 0) && search && (
         <p className="text-base text-g-sec text-center mt-8">Aucune culture pour « {search} ».</p>
       )}
-
-      {/* Graphe */}
-      <Chart cultures={stocks} />
     </div>
   )
 }

--- a/main.py
+++ b/main.py
@@ -19,7 +19,7 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.responses import FileResponse
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
-from sqlalchemy import func
+from sqlalchemy import func, or_
 from sqlalchemy.orm import joinedload
 
 # ── Version [US-008] ────────────────────────────────────────────────────────────
@@ -638,8 +638,8 @@ def get_godets(date_ref: date = Query(default=None)):
     db = SessionLocal()
     try:
         tous = calcul_godets(db, include_epuises=True, date_ref=dr)
-        en_attente  = [v for v in tous.values() if v["stock_residuel_godet"] > 0]
-        tout_plante = [v for v in tous.values() if v["stock_residuel_godet"] == 0]
+        en_attente  = [v for v in tous.values() if v["stock_residuel_godet"] > 0 or v.get("graines_en_germination", 0) > 0]
+        tout_plante = [v for v in tous.values() if v["stock_residuel_godet"] == 0 and not v.get("graines_en_germination")]
         return {
             "en_attente": en_attente,
             "tout_plante": tout_plante,
@@ -675,17 +675,30 @@ def get_godet_detail(culture: str = Query(...), variete: str = Query(default=Non
 
         godet_ids = {str(g.id) for g in godet_events}
 
-        # 2. Semis parents distincts via origine_graines_id
-        semis_ids = {g.origine_graines_id for g in godet_events if g.origine_graines_id}
-        semis_events = []
-        if semis_ids:
-            semis_events = (
-                db.query(Evenement)
-                .options(joinedload(Evenement.parcelle_rel))
-                .filter(Evenement.id.in_(semis_ids))
-                .order_by(Evenement.date.asc())
-                .all()
-            )
+        # 2. Semis "pépinière" pour cette culture/variété — rattachés à un godet ou
+        # pas encore transformés (stade "en germination", voir calcul_godets /
+        # utils/stock.py). Filtre direct par culture/variété plutôt que via
+        # origine_graines_id : un semis sans mise_en_godet associée doit quand
+        # même apparaître ici.
+        # ⚠️ Un semis pleine terre (parcelle réelle non-pépinière, ex: 2 m² sur
+        # "planche-test") appartient à un cycle totalement différent — planté
+        # directement en terre, jamais transformé en godet. Le mélanger ici avec
+        # les semis pépinière du même couple culture/variété n'a pas de sens
+        # (unité différente en plus : m² vs graines) : on l'exclut avec le même
+        # critère que calcul_godets (parcelle_id NULL ou parcelle.est_pepiniere).
+        semis_q = (
+            db.query(Evenement)
+            .options(joinedload(Evenement.parcelle_rel))
+            .outerjoin(Parcelle, Evenement.parcelle_id == Parcelle.id)
+            .filter(Evenement.type_action == "semis")
+            .filter(func.lower(Evenement.culture) == culture_lower)
+            .filter(or_(Evenement.parcelle_id.is_(None), Parcelle.est_pepiniere.is_(True)))
+        )
+        if variete:
+            semis_q = semis_q.filter(func.lower(Evenement.variete) == variete.lower())
+        else:
+            semis_q = semis_q.filter(Evenement.variete.is_(None))
+        semis_events = semis_q.order_by(Evenement.date.asc()).all()
 
         # 3. Plantations liées via source_evenement_ids
         plantation_candidates = (
@@ -739,6 +752,7 @@ def get_godet_detail(culture: str = Query(...), variete: str = Query(default=Non
                     "id":        s.id,
                     "date":      str(s.date)[:10],
                     "nb_graines": int(s.quantite or 0),
+                    "unite":     s.unite or "graines",
                     "parcelle":  s.parcelle_rel.nom if s.parcelle_rel else None,
                 }
                 for s in semis_events

--- a/tests/test_us_plan_occupation_parcelles.py
+++ b/tests/test_us_plan_occupation_parcelles.py
@@ -616,8 +616,9 @@ class TestSemisPleineTerre:
         assert len(est) == 1
         assert 9 <= est[0]["age_jours"] <= 11
 
-    def test_semis_sans_parcelle_absent_du_plan(self, test_db) -> None:
-        """Un semis sans parcelle_id n'apparaît PAS dans calcul_occupation_parcelles."""
+    def test_semis_sans_parcelle_dans_non_localise(self, test_db) -> None:
+        """[fix visibilité semis sans parcelle] Un semis sans parcelle_id apparaît
+        sous le groupe "Non localisé" (clé None) au lieu de disparaître du plan."""
         test_db.add(CultureConfig(nom="carotte", type_organe_recolte="végétatif"))
         test_db.add(Evenement(
             type_action="semis",
@@ -629,8 +630,11 @@ class TestSemisPleineTerre:
         ))
         test_db.commit()
         result = calcul_occupation_parcelles(test_db)
-        # Pas de plantation → aucune culture active → aucune entrée dans le plan
-        assert result == {}
+        non_localise = result.get(None, [])
+        assert len(non_localise) == 1
+        assert non_localise[0]["culture"] == "carotte"
+        assert non_localise[0]["nb_plants"] == 50.0
+        assert non_localise[0].get("type_action") == "semis"
 
     def test_semis_pleine_terre_unite(self, db_with_semis_pleine_terre) -> None:
         """L'unité du semis (graines) est conservée dans le résultat."""

--- a/utils/parcelles.py
+++ b/utils/parcelles.py
@@ -468,12 +468,16 @@ def calcul_occupation_parcelles(db: Session, date_ref: Optional[_date] = None) -
         ):
             groupes[key]["date_premiere"] = date_evt
 
-    # ── 3b. Semis pleine terre (parcelle_id non null, hors parcelles pépinière) ──
+    # ── 3b. Semis pleine terre + non localisés (hors parcelles pépinière) ──────
     # Un semis avec une VRAIE parcelle_id de pleine terre = semé directement en
     # terre (pas pépinière). Un semis rattaché à une parcelle est_pepiniere=true
     # (serre, pépinière, ou la parcelle factice "Non localisé") reste un semis
-    # pépinière sans localisation. Traité séparément des plantations — pas de
-    # filtre cultures_actives.
+    # pépinière sans localisation.
+    # [fix visibilité semis sans parcelle] Un semis SANS parcelle_id du tout
+    # (aucune parcelle précisée à la dictée) n'était auparavant inclus dans
+    # aucune vue — il rejoint ici le groupe "Non localisé" (parcelle=None),
+    # au même titre que les plantations sans parcelle (CA7 plus bas).
+    # Traité séparément des plantations — pas de filtre cultures_actives.
     _q_semis_pt = (
         db.query(
             Evenement.culture,
@@ -485,7 +489,10 @@ def calcul_occupation_parcelles(db: Session, date_ref: Optional[_date] = None) -
         )
         .outerjoin(Parcelle, Evenement.parcelle_id == Parcelle.id)
         .filter(Evenement.type_action == "semis")
-        .filter(_cond_semis_pleine_terre(Evenement, Parcelle))
+        .filter(
+            (Evenement.parcelle_id.is_(None))
+            | _cond_semis_pleine_terre(Evenement, Parcelle)
+        )
         .order_by(Evenement.date)
     )
     if cutoff is not None:

--- a/utils/stock.py
+++ b/utils/stock.py
@@ -443,23 +443,32 @@ def calcul_semis(db: Session, date_ref: Optional[_date] = None) -> Dict[str, dic
         if c.lower() not in cultures_avec_godets
     }
 
-    # Parcelles de semis pleine terre (parcelle_id non null, hors "Non localisé") par culture
+    # Parcelles de semis pleine terre par culture, "Non localisé" inclus.
+    # [fix visibilité semis sans parcelle] Un semis sans parcelle_id (aucune
+    # parcelle précisée à la dictée) n'est ni une vraie localisation pleine
+    # terre, ni rattaché à une parcelle pépinière/serre — il ne doit pas pour
+    # autant disparaître de l'affichage : il rejoint le groupe "Non localisé",
+    # au même titre que les plantations sans parcelle (CA7, utils/parcelles.py).
+    from sqlalchemy import or_ as _sa_or, and_ as _sa_and
     _q_parcelles_pt = (
-        db.query(Evenement.culture, Parcelle.nom)
-        .join(Parcelle, Evenement.parcelle_id == Parcelle.id)
+        db.query(Evenement.culture, Evenement.parcelle_id, Parcelle.nom)
+        .outerjoin(Parcelle, Evenement.parcelle_id == Parcelle.id)
         .filter(Evenement.type_action == "semis")
-        .filter(_cond_semis_pleine_terre(Evenement, Parcelle))
-        .filter(Parcelle.actif.is_(True))
+        .filter(_sa_or(
+            Evenement.parcelle_id.is_(None),
+            _sa_and(Parcelle.est_pepiniere.is_(False), Parcelle.actif.is_(True)),
+        ))
     )
     if cutoff is not None:
         _q_parcelles_pt = _q_parcelles_pt.filter(Evenement.date <= cutoff)
     parcelles_pt_raw = _q_parcelles_pt.all()
     parcelles_pt: Dict[str, list] = {}
-    for culture_pt, nom_p in parcelles_pt_raw:
+    for culture_pt, parcelle_id_pt, nom_p in parcelles_pt_raw:
+        nom_affiche = nom_p if parcelle_id_pt is not None else "Non localisé"
         if culture_pt not in parcelles_pt:
             parcelles_pt[culture_pt] = []
-        if nom_p not in parcelles_pt[culture_pt]:
-            parcelles_pt[culture_pt].append(nom_p)
+        if nom_affiche not in parcelles_pt[culture_pt]:
+            parcelles_pt[culture_pt].append(nom_affiche)
 
     result: Dict[str, dict] = {}
     for culture, (total_seme, unite_dominante) in semis_resolus.items():
@@ -962,9 +971,9 @@ def calcul_godets(db: Session, include_epuises: bool = False, date_ref: Optional
     if cutoff is not None:
         _q_rows = _q_rows.filter(Evenement.date <= cutoff)
     rows = _q_rows.all()
-
-    if not rows:
-        return {}
+    # [fix visibilité semis pépinière] Pas de retour anticipé même si aucun
+    # mise_en_godet n'existe : des semis "en germination" peuvent quand même
+    # être présents plus bas (voir bloc semis_par_cv en fin de fonction).
 
     # [US-029] Taux de germination : calculer depuis les semis parents (origine_graines_id)
     # nb_graines_semees sur une mise_en_godet est un champ contextuel par lot, pas le total réel
@@ -1103,6 +1112,60 @@ def calcul_godets(db: Session, include_epuises: bool = False, date_ref: Optional
             "stock_residuel_godet": stock_residuel,
             "taux_reussite":        taux,
         }
+
+    # [fix visibilité semis pépinière] Un semis rattaché à une parcelle pépinière
+    # (serre, "Non localisé"...) ou sans parcelle du tout est un stade "en
+    # germination" — pas encore repiqué en godet (mise_en_godet). Sans ce bloc,
+    # ces graines ne remontent dans AUCUNE vue : ni "pleine terre" (exclues par
+    # _cond_semis_pleine_terre), ni "pépinière" (calculée uniquement depuis
+    # mise_en_godet). On les fusionne donc ici dans le même dict que les godets,
+    # avec un statut dédié quand aucune mise_en_godet n'existe encore pour ce
+    # couple (culture, variete).
+    from sqlalchemy import or_ as _sa_or
+    _q_semis_pep = (
+        db.query(Evenement.culture, Evenement.variete, Evenement.quantite, Evenement.unite)
+        .outerjoin(Parcelle, Evenement.parcelle_id == Parcelle.id)
+        .filter(Evenement.type_action == "semis")
+        .filter(Evenement.culture.isnot(None))
+        .filter(_sa_or(Evenement.parcelle_id.is_(None), Parcelle.est_pepiniere.is_(True)))
+    )
+    if cutoff is not None:
+        _q_semis_pep = _q_semis_pep.filter(Evenement.date <= cutoff)
+    semis_par_cv: Dict[tuple, Dict[str, float]] = {}
+    for culture, variete, qte, unite in _q_semis_pep.all():
+        u = unite or "graines"
+        sous_total = semis_par_cv.setdefault((culture, variete), {})
+        sous_total[u] = sous_total.get(u, 0.0) + (qte or 0.0)
+
+    for (culture, variete), par_unite in semis_par_cv.items():
+        unite_dom = max(par_unite, key=par_unite.get)
+        total_seme = par_unite[unite_dom]
+        consommees = graines_par_cv.get((culture, variete), 0)
+        reste = max(0, total_seme - consommees)
+        if reste <= 0:
+            continue
+
+        key = culture + (f" ({variete})" if variete else "")
+        if key in result:
+            result[key]["graines_en_germination"] = int(reste)
+            result[key]["unite_germination"]      = unite_dom
+        else:
+            result[key] = {
+                "culture":               culture,
+                "variete":               variete,
+                "nb_godets":             0,
+                "nb_graines_semees":     0,
+                "nb_plants_godets":      0,
+                "nb_plantes":            0,
+                "nb_vendus":             0,
+                "nb_pertes_godet":       0,
+                "stock_residuel_godet":  0,
+                "taux_reussite":         None,
+                "graines_en_germination": int(reste),
+                "unite_germination":      unite_dom,
+                "statut":                 "en_germination",
+            }
+
     return dict(sorted(result.items()))
 
 


### PR DESCRIPTION
## Résumé

Un semis sans parcelle, ou rattaché à une parcelle marquée pépinière (serre, la
parcelle synthétique « Non localisé »...), disparaissait complètement de
l'application :

- exclu du plan d'occupation (`/plan` Telegram)
- absent du dashboard "Stocks cultures"
- jamais repris dans "En pépinière" (calculée uniquement depuis les événements
  `mise_en_godet`, jamais depuis les `semis` bruts)

Le flag `parcelles.est_pepiniere` (migration_v15) servait uniquement à
*exclure* ces semis du calcul "pleine terre", sans jamais les faire
réapparaître ailleurs.

## Changements

- `calcul_semis` / `calcul_occupation_parcelles` (`utils/stock.py`,
  `utils/parcelles.py`) : un semis sans parcelle rejoint le groupe
  "Non localisé" au lieu de disparaître.
- `calcul_godets` (`utils/stock.py`) : fusionne les semis pépinière pas
  encore repiqués en godet dans le même flux que les godets, avec un statut
  `en_germination` dédié — visible dans le dashboard "Pépinière".
- `/godets/detail` (`main.py`) : le panneau "cycle de vie" ne montre que les
  semis pépinière du couple culture/variété (même critère que
  `calcul_godets`) — évite de mélanger un semis pleine terre indépendant
  (unité différente, parcelle différente) dans le même historique.
- Frontend (`Stocks.jsx`, `Pepiniere.jsx`) : badges et libellés adaptés
  (badge "Non localisé", carte "🌱 En germination" avec unité réelle au lieu
  de "graines" figé).
- `tests/test_us_plan_occupation_parcelles.py` mis à jour (le test vérifiait
  l'ancien comportement bugué).

## Test plan

- [x] `pytest tests/` — 581 passent, 35 échecs pré-existants inchangés (baseline
      vérifiée par comparaison avant/après)
- [x] `npm run build` (frontend) sans erreur
- [x] Reproduction manuelle du scénario rapporté (semis 10 graines haricot
      blanc → parcelle pépinière) : `calcul_godets()` retourne bien l'entrée
      `statut: "en_germination"`
- [ ] Vérification visuelle sur dev après déploiement

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>