### PR TITLE
chore(ci): renommer les workflows de deploiement

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -1,4 +1,4 @@
-name: Deploy to Scaleway (DEV)
+name: Deploy Dev
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 on:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: Deploy to Scaleway
+name: Deploy Production
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 on:


### PR DESCRIPTION
## Résumé
Renomme les deux workflows de déploiement pour clarifier l'environnement cible plutôt que l'hébergeur :
- `Deploy to Scaleway` → `Deploy Production`
- `Deploy to Scaleway (DEV)` → `Deploy Dev`

Aucun changement fonctionnel (déclencheurs, cibles serveur, services systemd inchangés).

## Fichiers concernés
`.github/workflows/deploy.yml`, `.github/workflows/deploy-dev.yml`