### PR TITLE
fix(ci): variables psql manquantes pour migration_v16.sql (dev+prod)

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -88,7 +88,7 @@ jobs:
                 continue
               fi
               echo \"  >>> Applying \${migration}...\"
-              psql \"\${DATABASE_URL}\" -v ON_ERROR_STOP=1 -v app_user_password='${{ secrets.APP_USER_PASSWORD }}' -f \"\${migration}\"
+              psql \"\${DATABASE_URL}\" -v ON_ERROR_STOP=1 -v chat_id_actuel='' -v lat_actuelle='' -v lon_actuelle='' -v app_user_password='${{ secrets.APP_USER_PASSWORD }}' -f \"\${migration}\"
               echo \"\${name}\" >> \"\${APPLIED_LOG}\"
             done
           "

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -90,7 +90,7 @@ jobs:
                 continue
               fi
               echo \"  >>> Applying \${migration}...\"
-              psql \"\${DATABASE_URL}\" -v ON_ERROR_STOP=1 -v app_user_password='${{ secrets.APP_USER_PASSWORD }}' -f \"\${migration}\"
+              psql \"\${DATABASE_URL}\" -v ON_ERROR_STOP=1 -v chat_id_actuel='' -v lat_actuelle='' -v lon_actuelle='' -v app_user_password='${{ secrets.APP_USER_PASSWORD }}' -f \"\${migration}\"
               echo \"\${name}\" >> \"\${APPLIED_LOG}\"
             done
           "


### PR DESCRIPTION
## Contexte

Le déploiement dev suite au merge de #101 a échoué à l'étape "Apply SQL migrations" :

```
psql:migrations/migration_v16.sql:87: ERROR:  syntax error at or near ":"
LINE 2: SELECT 1, NULL, NULLIF(:'chat_id_actuel', '')::BIGINT, 'Emma...
```

`migration_v16.sql` référence `:'chat_id_actuel'`, `:'lat_actuelle'`, `:'lon_actuelle'`, jamais passées via `-v` par le workflow. Contrairement à l'hypothèse initiale (celle qui avait motivé le fix `app_user_password` de #101), psql ne substitue pas une variable totalement non définie par une chaîne vide : il laisse le token `:'nom'` littéral dans le SQL envoyé au serveur, provoquant une erreur de syntaxe.

**Aucune casse constatée** : la migration est dans un `BEGIN`/`COMMIT`, l'erreur est survenue avant le `COMMIT` → rollback automatique, rien n'a été créé en base. `.migrations_applied` n'a pas été mis à jour. Le job a échoué avant l'étape de redémarrage des services → `potager-dev.service` a continué de tourner sur l'ancienne version (vérifié : `/health` répondait toujours `200` en v3.14.0 après l'échec).

## Fix

Ajoute `-v chat_id_actuel='' -v lat_actuelle='' -v lon_actuelle=''` (repli vide déjà documenté dans l'en-tête de `migration_v16.sql` : NULL pour le chat_id, coordonnées par défaut) dans `deploy-dev.yml` **et** `deploy.yml` (même faille présente dans les deux).

## Test plan

- [x] `yaml.safe_load` sur les deux workflows modifiés
- [ ] Prochain merge vers `dev` : vérifier que `migration_v16.sql`, `v17.sql`, `v18.sql` s'appliquent sans erreur et que le smoke test passe

🤖 Généré avec [Claude Code](https://claude.com/claude-code)