### PR TITLE
fix(migration): \gexec au lieu de DO $$ pour creer app_user

### DIFF
--- a/migrations/migration_v18.sql
+++ b/migrations/migration_v18.sql
@@ -77,12 +77,18 @@
 BEGIN;
 
 -- [1] Rôle applicatif non-superuser, distinct du rôle admin/propriétaire.
-DO $$
-BEGIN
-    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'app_user') THEN
-        EXECUTE format('CREATE ROLE app_user LOGIN PASSWORD %L', :'app_user_password');
-    END IF;
-END $$;
+-- [Correctif déploiement réel] :'app_user_password' ne doit PAS être
+-- référencée à l'intérieur d'un bloc DO $$ ... $$ : psql n'interpole pas les
+-- variables à l'intérieur d'une chaîne dollar-quotée (c'est tout le principe
+-- du dollar-quoting — contenir du texte arbitraire sans interprétation), le
+-- texte littéral ":'app_user_password'" part alors tel quel vers le serveur,
+-- qui échoue avec "syntax error at or near ':'". \gexec s'exécute au niveau
+-- top-level du script, hors de tout dollar-quoting : l'interpolation
+-- fonctionne normalement, et n'exécute la commande générée QUE si la ligne
+-- est retournée (donc uniquement si le rôle n'existe pas déjà).
+SELECT format('CREATE ROLE app_user LOGIN PASSWORD %L', :'app_user_password')
+WHERE NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'app_user')
+\gexec
 
 -- [2] Droits nécessaires — RLS filtre les LIGNES, il ne remplace pas les
 -- droits SQL standards : app_user a besoin des GRANT habituels sur toutes


### PR DESCRIPTION
## Contexte

Suite au fix de #106 (variables psql de migration_v16.sql), le déploiement dev a de nouveau échoué, cette fois sur `migration_v18.sql` :

```
psql:migrations/migration_v18.sql:85: ERROR:  syntax error at or near ":"
LINE 4: ... format('CREATE ROLE app_user LOGIN PASSWORD %L', :'app_user...
```

`migration_v16.sql` et `v17.sql` sont passées avec succès (`potager_id NOT NULL` posé, 0 ligne orpheline) et sont marquées appliquées sur le serveur — seule `v18.sql` doit être rejouée.

## Cause

`:'app_user_password'` était bien passée en `-v` (confirmé dans les logs), mais référencée **à l'intérieur d'un bloc `DO $$ ... $$`**. psql n'interpole pas les variables `:'nom'` dans une chaîne dollar-quotée — c'est le principe même du dollar-quoting (contenir du texte arbitraire sans interprétation). Le texte littéral partait donc tel quel vers le serveur.

## Fix

Remplace le bloc `DO $$...$$` par `\gexec` (méta-commande psql, s'exécute au niveau top-level du script, hors dollar-quoting) : la commande `CREATE ROLE` n'est générée/exécutée que si le rôle n'existe pas déjà, avec la variable correctement interpolée cette fois.

## Test plan

- [ ] Prochain merge vers `dev` : vérifier que `migration_v18.sql` s'applique sans erreur (`v16`/`v17` seront sautées, déjà marquées appliquées) et que le smoke test passe

🤖 Généré avec [Claude Code](https://claude.com/claude-code)