### PR TITLE
fix(ci): accorde CREATEROLE a potager_user avant les migrations

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -71,6 +71,7 @@ jobs:
         run: |
           ssh ${{ secrets.SCALEWAY_USER }}@${{ secrets.SCALEWAY_HOST }} "
             sudo -u postgres psql -d potager_dev -c 'CREATE EXTENSION IF NOT EXISTS unaccent;'
+            sudo -u postgres psql -c 'ALTER ROLE potager_user CREATEROLE;'
           "
 
       - name: Apply SQL migrations

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -73,6 +73,7 @@ jobs:
         run: |
           ssh ${{ secrets.SCALEWAY_USER }}@${{ secrets.SCALEWAY_HOST }} "
             sudo -u postgres psql -d potager_prod -c 'CREATE EXTENSION IF NOT EXISTS unaccent;'
+            sudo -u postgres psql -c 'ALTER ROLE potager_user CREATEROLE;'
           "
 
       - name: Apply SQL migrations


### PR DESCRIPTION
## Contexte

Suite au fix de #107 (`\gexec` au lieu de `DO $$`), `migration_v18.sql` avance mais échoue désormais avec :

```
psql:migrations/migration_v18.sql:91: ERROR:  permission denied to create role
```

`migration_v16.sql` et `v17.sql` sont déjà appliquées et marquées dans `.migrations_applied` — seule `v18.sql` doit être rejouée.

## Cause

`potager_user` (rôle utilisé via `DATABASE_URL` pour les migrations) n'a pas l'attribut `CREATEROLE`. En PostgreSQL, seul un superuser ou un rôle avec `CREATEROLE` peut faire `CREATE ROLE` — `potager_user` est propriétaire des tables mais pas superuser.

## Fix

Ajoute `ALTER ROLE potager_user CREATEROLE;` (idempotent) via `sudo -u postgres`, dans la même étape "Setup PostgreSQL extensions" qui crée déjà l'extension `unaccent` de la même façon — dans `deploy-dev.yml` **et** `deploy.yml` (`potager_dev`/`potager_prod` partagent le même cluster, donc le même rôle `potager_user` ; présent dans les deux workflows par cohérence).

## Test plan

- [ ] Prochain merge vers `dev` : vérifier que `migration_v18.sql` s'applique intégralement (rôle `app_user` créé, RLS activé, policies posées) et que le smoke test passe

🤖 Généré avec [Claude Code](https://claude.com/claude-code)