### PR TITLE
docs(multitenant): recupere le backlog epic 2 (US-044 a US-048)

### DIFF
--- a/.github/BACKLOG_US_MULTITENANT.md
+++ b/.github/BACKLOG_US_MULTITENANT.md
@@ -1,0 +1,236 @@
+# 🌿 Assistant Potager — Backlog US Multi-tenant & Sécurisation
+
+> **Document de référence pour Claude Code et l'agent de rédaction d'US.**
+> Objectif : solution 100 % multi-utilisateurs, sécurisée, prête à commercialisation.
+> Source : `REFLEXION_STRATEGIQUE_multi_utilisateurs.md` (§4 bloquants, §5 architecture cible, §7 trajectoire).
+> Convention : chaque US ci-dessous est à décliner au format `US-XXX` habituel (critères d'acceptance + Gherkin) par l'agent US, puis implémentée par l'agent d'implémentation.
+> Règle d'or transverse : **aucune US ne casse l'installation actuelle**. Les données existantes deviennent le potager #1.
+
+---
+
+## 0. Vue d'ensemble — ordre et dépendances
+
+```
+ÉPIC 1 — SOCLE TENANT          ÉPIC 2 — IDENTITÉ & ACCÈS      ÉPIC 3 — FIABILITÉ & COÛT      ÉPIC 4 — COMMERCIALISATION
+US-100 Modèle multi-tenant ──► US-110 Auth web (JWT)      ──► US-120 État Redis          ──► US-130 Postgres managé
+US-101 Couche services     ──► US-111 Liaison Telegram    ──► US-121 LLM à étages        ──► US-131 Observabilité
+US-102 Scoping requêtes    ──► US-112 Potager actif       ──► US-122 RAG scopé /ask      ──► US-132 RGPD
+US-103 RLS PostgreSQL      ──► US-113 Rôles & permissions ──► US-123 Quotas par tenant   ──► US-133 Stripe / freemium
+                               US-114 Invitations         ──► US-124 Jobs par potager
+                                                              US-125 Alembic + CI/CD
+```
+
+**Chemin critique :** `US-100 → US-101 → US-102 → US-103 → US-110 → US-111 → US-113`.
+Tout le reste peut être parallélisé une fois son épic amont livré.
+
+**Chantier parallèle (hors périmètre de ce backlog, à ne pas oublier) :** la base de connaissance *fiches cultures* (`US_Base_fiches_cultures`), qui conditionne la valeur produit de l'offre payante. À mener en parallèle des épics 1–2, car sans elle on commercialise « un carnet multi-utilisateurs », facilement copiable.
+
+---
+
+## ÉPIC 1 — Socle multi-tenant (Phase 0–1 de la trajectoire)
+
+### US-100 — Modèle multi-tenant (users / potagers / membres)
+
+- **Contexte :** aucune notion de tenant aujourd'hui ; tables globales. Bloquant #1.
+- **Objectif :** créer le socle de données du tenant **potager** (pas l'utilisateur — 500 users / 100 potagers ≈ 5 personnes/jardin, les jardins sont partagés).
+- **Périmètre :**
+  - Tables `users (id, email, telegram_chat_id UNIQUE NULL, cree_le)`, `potagers (id, nom, latitude, longitude, proprietaire_id FK users, cree_le)`, `potager_membres (user_id, potager_id, role CHECK IN ('owner','editor','lecteur'), PRIMARY KEY (user_id, potager_id))`.
+  - Ajout `potager_id INTEGER NULL REFERENCES potagers(id)` sur **toutes** les tables métier : `evenements`, `parcelles`, `culture_config`, et toute table dérivée.
+  - Backfill : création du user #1 (Emmanuel, chat_id actuel), du potager #1 (localisation actuelle), rattachement owner, `UPDATE ... SET potager_id = 1` sur toutes les lignes existantes.
+  - Index : `CREATE INDEX ... ON evenements (potager_id, date DESC)` (et équivalent sur les autres tables).
+- **Hors périmètre :** aucun changement de comportement du bot ; les colonnes restent nullables à ce stade.
+- **Migration :** `migration_v5.sql` complet, rejouable (idempotent : `IF NOT EXISTS`), exécutable via `psql`.
+- **Critères d'acceptance clés :** bot et PWA fonctionnent à l'identique après migration ; `SELECT count(*) FROM evenements WHERE potager_id IS NULL` = 0 après backfill ; rollback documenté.
+- **Impact tokens :** nul. **Risques :** oubli d'une table dérivée → inventorier via `information_schema` dans l'US.
+
+### US-101 — Couche `services/` partagée bot ⇄ PWA
+
+- **Contexte :** logique métier éclatée entre `bot.py` (~1300 lignes) et `main.py`. Si l'isolation est codée deux fois, elle sera fausse une fois.
+- **Objectif :** extraire la logique métier dans `app/services/` ; chaque fonction de service prend **obligatoirement** un contexte `TenantContext(user_id, potager_id, role)`. Bot et FastAPI deviennent des clients minces.
+- **Périmètre :** modules suggérés : `services/evenements.py` (CRUD + corrections), `services/stats.py`, `services/stock.py`, `services/plan.py`, `services/questions.py` (`_ask_question`). Signature type : `def enregistrer_evenement(ctx: TenantContext, data: EvenementIn) -> Evenement`.
+- **Hors périmètre :** pas encore de vérification des rôles (US-113) ; `ctx` peut être construit avec le potager #1 en dur pendant la transition.
+- **Critères d'acceptance clés :** aucun `db.query(Evenement)` ne subsiste dans `bot.py` / `main.py` ; comportement identique (tests de non-régression sur les 12 actions canoniques + flux `corr_*` + mode `ask`) ; logging structuré `HH:MM:SS │ LEVEL │ emoji` conservé.
+- **Risques / effets de bord :** refactor massif → découper en sous-US par module ; attention aux états `ctx.user_data` (Telegram) qui ne migrent PAS dans services (ils restent côté client bot jusqu'à US-120). SQLAlchemy 2.0 : `db.get()`, jamais `db.query().get()`.
+
+### US-102 — Scoping systématique par `potager_id` (dont refonte `_ask_question`)
+
+- **Contexte :** `_ask_question()` charge tout l'historique sans filtre (~5 000 tokens) : fuite inter-potagers + explosion de coût + débordement de contexte. Limiter à 100 événements ne suffit pas : il faut **scoper avant de limiter**.
+- **Objectif :** toute requête de la couche services filtre par `ctx.potager_id`. Zéro requête non scopée dans le code applicatif.
+- **Périmètre :**
+  - Filtre `potager_id` dans tous les services (lecture, écriture, correction, suppression, stats, stock, plan, rotation).
+  - `_ask_question` : scope potager + fenêtre temporelle (défaut 12 mois) + limite (100 événements max) ; sérialisation compacte.
+  - `potager_id` devient `NOT NULL` sur toutes les tables métier (`migration_v6.sql`).
+- **Critères d'acceptance clés (Gherkin type) :** *Étant donné* deux potagers A et B avec des événements, *quand* un membre de A demande stats/historique/question, *alors* aucune donnée de B n'apparaît. Test automatisé d'isolation obligatoire.
+- **Impact tokens :** `_ask_question` passe de ~5 000 à < 1 500 tokens/appel (à mesurer et logger).
+- **Risques :** requêtes brutes SQL éventuelles (stats) à auditer une par une.
+
+### US-103 — Row-Level Security PostgreSQL (défense en profondeur)
+
+- **Contexte :** même avec le scoping applicatif, un bug suffit pour fuir. Ceinture + bretelles.
+- **Objectif :** policies RLS garantissant qu'aucune requête ne sort du potager courant, même en cas de bug applicatif.
+- **Périmètre :**
+  - Rôle applicatif Postgres non-superuser (RLS ne s'applique pas au owner de table → créer `app_user`).
+  - `ALTER TABLE ... ENABLE ROW LEVEL SECURITY` + policy `USING (potager_id = current_setting('app.potager_id')::int)` sur chaque table métier.
+  - Dans `db.py` : à l'ouverture de session, `SET LOCAL app.potager_id = :pid` (event SQLAlchemy `after_begin` ou context manager de session tenant-aware).
+- **Migration :** `migration_v7.sql` (policies) + modification `database/db.py`.
+- **Critères d'acceptance clés :** une requête volontairement non scopée (test dédié) retourne 0 ligne d'un autre potager ; les migrations/backups (rôle admin) restent possibles.
+- **Risques :** oubli du `SET` → requêtes qui retournent 0 ligne partout (échec silencieux) : prévoir un fail-fast si `app.potager_id` absent ; jobs de fond (US-124) devront itérer en posant le setting par potager.
+
+---
+
+## ÉPIC 2 — Identité & accès (Phase 2–3)
+
+### US-110 — Authentification web (inscription + login JWT)
+
+- **Objectif :** identité e-mail/mot de passe pour la PWA ; tous les endpoints FastAPI protégés.
+- **Périmètre :** hash mot de passe (argon2 ou bcrypt via `passlib`) ; JWT access (15 min) + refresh (30 j) ; endpoints `/auth/register`, `/auth/login`, `/auth/refresh` ; dépendance FastAPI `get_current_user` appliquée à **tous** les endpoints métier ; construction du `TenantContext` depuis le JWT. Rate-limit basique sur `/auth/*`.
+- **Hors périmètre :** OAuth Google (évolution ultérieure), reset mot de passe par e-mail (peut être une sous-US si l'envoi d'e-mail n'est pas encore disponible).
+- **Critères d'acceptance clés :** endpoint sans token → 401 ; token expiré → 401 + refresh fonctionne ; mot de passe jamais loggé ni stocké en clair ; secrets (JWT_SECRET) via variables d'environnement, pas dans `config.py` versionné.
+- **Risques :** la PWA actuelle appelle l'API sans auth → coordonner front/back dans la même US.
+
+### US-111 — Liaison Telegram ⇄ compte web par code à usage unique
+
+- **Objectif :** rattacher un `chat_id` Telegram à un compte web. Un compte = un web + un Telegram liés.
+- **Périmètre :** génération d'un code court (6–8 caractères, TTL 10 min, usage unique) côté web ; commande `/lier <code>` (et détection du code en message texte) côté bot ; écriture `users.telegram_chat_id` ; le bot **refuse tout message d'un `chat_id` non lié** (message d'onboarding avec lien vers l'inscription).
+- **Critères d'acceptance clés :** code expiré/déjà utilisé → refus explicite ; un `chat_id` ne peut être lié qu'à un seul compte ; un chat inconnu ne peut déclencher **aucun** appel Groq (économie + sécurité).
+- **Effets de bord :** `handle_voice`/`handle_text` doivent vérifier la liaison **avant** toute transcription Whisper — placer le garde en tout premier dans le flux (avant les priorités 1–5).
+
+### US-112 — Sélection du potager actif
+
+- **Objectif :** un utilisateur peut appartenir à plusieurs potagers → notion de potager actif, stocké par utilisateur, côté web et Telegram.
+- **Périmètre :** colonne `users.potager_actif_id` (ou table de préférences) ; commande `/potager` avec boutons inline listant les potagers du membre ; sélecteur équivalent dans la PWA ; le `TenantContext` est construit depuis le potager actif ; si un seul potager → sélection automatique silencieuse.
+- **Critères d'acceptance clés :** après changement de potager actif, toutes les saisies/questions portent sur le nouveau potager ; utilisateur sans potager → invité à en créer un (lien avec US-114).
+- **Migration :** incluse dans `migration_v8.sql` avec US-111 si livrées ensemble.
+
+### US-113 — Rôles & permissions (owner / editor / lecteur)
+
+- **Objectif :** contrôle d'accès par rôle, écrit **une seule fois** dans la couche services.
+- **Périmètre :** matrice : `lecteur` = consultation (stats, historique, questions) ; `editor` = + saisie/correction/suppression d'événements ; `owner` = + gestion des membres, paramètres du potager, suppression du potager. Décorateur ou garde `require_role(ctx, 'editor')` dans chaque service d'écriture. Messages d'erreur clairs côté bot et PWA (« Tu es lecteur sur ce potager »).
+- **Critères d'acceptance clés (Gherkin type) :** *Étant donné* un lecteur, *quand* il dicte « j'ai récolté 2 kg de tomates », *alors* rien n'est enregistré et un message d'explication est renvoyé (et l'appel de parsing LLM n'a **pas lieu** — vérifier le rôle avant `parse_actions`).
+- **Impact tokens :** positif (blocage avant appel LLM pour les lecteurs).
+
+### US-114 — Invitations & onboarding self-service
+
+- **Objectif :** plus aucune opération manuelle pour créer un utilisateur ou un potager.
+- **Périmètre :** création de potager depuis la PWA (nom + localisation — la géolocalisation alimente la météo par potager, US-124) ; invitation de membre par e-mail ou lien/code d'invitation avec rôle proposé ; acceptation → insertion dans `potager_membres` ; parcours complet documenté : inscription → création/adhésion potager → liaison Telegram → première saisie.
+- **Critères d'acceptance clés :** un nouvel utilisateur atteint sa première saisie vocale sans aucune intervention de l'administrateur ; l'owner peut retirer un membre ; un membre retiré perd l'accès immédiatement (invalidation du potager actif).
+
+---
+
+## ÉPIC 3 — Fiabilité & maîtrise du coût (Phase 4) — *condition de survie économique*
+
+### US-120 — État conversationnel persistant (Redis)
+
+- **Contexte :** flux `corr_*` et mode `ask` en RAM (`ctx.user_data`) → perdus au redémarrage, non partageables, non scalables.
+- **Objectif :** état des conversations dans Redis, clé `state:{user_id}`, TTL (ex. 15 min), sérialisation JSON.
+- **Périmètre :** wrapper `ConversationState` (get/set/clear) remplaçant les accès `ctx.user_data` pour les modes ; docker-compose ajoute Redis ; fallback dégradé si Redis indisponible (mode sans état + log ERROR).
+- **Critères d'acceptance clés :** redémarrage du bot en plein flux `corr_select` → le flux reprend ; TTL expiré → retour au menu proprement.
+- **Risques / effets de bord :** c'est LE refactor sensible sur les états — tester les 5 priorités de `handle_text` et le bypass vocal ; conserver l'ordre critique (modes corr > ask > NAV > question > action).
+
+### US-121 — LLM à étages + parsing déterministe + cache
+
+- **Contexte :** goulot n°1 du projet = tokens Groq, pas l'infra.
+- **Objectif :** réduire drastiquement le coût par message.
+- **Périmètre :**
+  1. `classify_intent()` → `llama-3.1-8b-instant` (~×9 d'économie), 70B réservé au parsing structuré.
+  2. Parseur déterministe (regex/grammaire) **avant** tout appel LLM pour les formes fréquentes (« récolté 2 kg de tomates », « semé 3 rangs de carottes parcelle nord ») → zéro token sur ces cas ; le LLM devient le fallback.
+  3. Cache de classification (Redis, clé = hash du texte normalisé, TTL 24 h) pour les phrases courtes identiques.
+  4. Log du nombre de tokens consommés par appel (colonne ou log structuré) pour mesurer.
+- **Critères d'acceptance clés :** jeu de tests de non-régression sur un corpus de phrases réelles (extraites de `texte_original`) : le parseur déterministe couvre ≥ 50 % des saisies sans dégrader la précision ; taux d'erreur d'intent mesuré avant/après bascule 8B.
+- **Impact tokens :** cible 🔶 : coût moyen/message divisé par 5 à 10. **Risques :** le 8B classe moins bien → garder un fallback 70B si confiance faible ; ne pas oublier `.replace()` (jamais `.format()`) dans les prompts.
+
+### US-122 — RAG scopé et pré-agrégé pour les questions (`/ask`)
+
+- **Contexte :** complément de US-102 : après le scoping, optimiser la *qualité/coût* des réponses.
+- **Objectif :** ne jamais envoyer de lignes brutes massives au LLM ; pré-agréger en SQL, nourrir le LLM avec des résumés.
+- **Périmètre :** classification légère de la question (culture ? période ? type de question ?) ; requêtes SQL d'agrégation ciblées (totaux par culture/mois, dernières occurrences) ; contexte final < 1 000 tokens ; fenêtre temporelle adaptative selon la question.
+- **Critères d'acceptance clés :** corpus de questions réelles → réponses correctes avec contexte < 1 000 tokens ; aucune donnée hors `potager_id`.
+- **Impact tokens :** ~5 000 → < 1 500 par question (mesuré).
+
+### US-123 — Quotas tokens & rate-limiting par tenant
+
+- **Contexte :** quota Groq global partagé = non viable ; le prix de l'offre doit couvrir le coût réel/user/mois.
+- **Objectif :** comptabiliser et plafonner la consommation par potager.
+- **Périmètre :** table `conso_tokens (potager_id, date, appel_type, modele, tokens_in, tokens_out)` alimentée par un wrapper unique autour du client Groq ; budget quotidien/mensuel par potager (colonne `potagers.plan` : free/payant) ; dépassement → message clair + blocage des appels LLM (les fonctions déterministes restent disponibles) ; rate-limit par user (ex. N messages/minute) ; endpoint/commande de consultation de conso.
+- **Critères d'acceptance clés :** potager au quota → saisies simples via parseur déterministe encore possibles, questions LLM bloquées avec message d'upgrade ; tableau de conso par potager consultable (base du pricing).
+- **Dépendances :** US-121 (wrapper Groq unique).
+
+### US-124 — Jobs de fond par potager (météo, sauvegardes, alertes)
+
+- **Contexte :** météo mono-localisation, job global 5h, aucune sauvegarde automatique.
+- **Objectif :** ordonnanceur qui itère sur les potagers.
+- **Périmètre :** APScheduler (Celery/RQ seulement si ça grossit) ; job météo par `(lat, lon)` distinct avec cache `(lat, lon, jour)` et batching Open-Meteo ; alertes gel/canicule envoyées aux membres du potager concerné via Telegram ; job de sauvegarde quotidien (`pg_dump` + rétention 30 j) tant que US-130 n'est pas livrée ; chaque job pose `app.potager_id` (compatibilité RLS, cf. US-103).
+- **Critères d'acceptance clés :** 2 potagers à localisations différentes reçoivent des météos différentes ; échec d'un job pour un potager n'interrompt pas les autres (isolation d'erreurs + log).
+
+### US-125 — Migrations Alembic + CI/CD
+
+- **Contexte :** migrations jouées à la main → intenable en prod multi-tenant vivante.
+- **Objectif :** migrations versionnées et déploiement reproductible.
+- **Périmètre :** init Alembic + reprise de l'état actuel comme révision de base (les `migration_vX.sql` historiques restent en archive) ; docker-compose (FastAPI + bot + Redis) ; GitHub Actions : tests → build → déploiement Scaleway → `alembic upgrade head` → restart services ; secrets en variables d'environnement/GitHub Secrets.
+- **Critères d'acceptance clés :** un `git push` sur `main` déploie sans intervention manuelle et sans coupure perceptible ; rollback de migration documenté et testé.
+
+---
+
+## ÉPIC 4 — Commercialisation (Phase 5)
+
+### US-130 — PostgreSQL managé + sauvegardes automatiques
+
+- **Périmètre :** migration vers Postgres managé Scaleway (sauvegardes auto, PITR) ; bascule `DATABASE_URL` ; répétition générale de la migration sur une copie ; fenêtre de coupure planifiée et courte.
+- **Critères d'acceptance clés :** restauration testée réellement (pas seulement des backups qui existent) ; latence applicative inchangée.
+
+### US-131 — Observabilité
+
+- **Périmètre :** Sentry (bot + API) ; logs centralisés ; métriques : messages/jour, erreurs, latence Groq, **tokens par tenant** (réutilise US-123) ; alerte si taux d'erreur anormal ou quota Groq global proche de la limite.
+- **Critères d'acceptance clés :** une exception non gérée en prod apparaît dans Sentry avec contexte (user_id, potager_id — sans données personnelles sensibles).
+
+### US-132 — RGPD & conformité
+
+- **Contexte :** pré-requis légal de commercialisation dès qu'il y a des données de tiers.
+- **Périmètre :** export des données du compte (JSON/CSV) ; suppression de compte (et anonymisation des événements d'un potager partagé : l'événement reste, l'auteur est anonymisé) ; consentement à l'inscription ; CGU + politique de confidentialité + mentions légales ; registre des traitements (document) ; TTL sur les fichiers audio temporaires (les vocaux ne sont pas conservés après transcription).
+- **Critères d'acceptance clés :** suppression de compte → plus aucune donnée personnelle en base (vérification par requête) ; export complet en < 1 min.
+- **Risques :** cas du dernier owner d'un potager qui supprime son compte → règle à définir dans l'US (transfert ou suppression du potager).
+
+### US-133 — Facturation Stripe (freemium)
+
+- **Périmètre :** plans free (quota tokens limité, 1 potager) / payant (quotas supérieurs, potagers multiples, fonctions premium — ex. prévision de récolte, diagnostic photo) ; Stripe Checkout + webhooks (paiement, échec, résiliation) ; `potagers.plan` piloté par l'abonnement ; page de gestion d'abonnement.
+- **Critères d'acceptance clés :** cycle complet testé en mode test Stripe : souscription → upgrade quota effectif → résiliation → retour au plan free en fin de période.
+- **Dépendances :** US-123 (quotas), US-132 (CGU obligatoires avant encaissement). **Pré-requis business :** mesurer 1 mois de conso réelle (US-123) pour fixer un prix couvrant le coût Groq/user/mois.
+
+---
+
+## Annexes pour l'agent US
+
+### Ordre de livraison recommandé (sprints indicatifs)
+
+| Sprint | US | Livrable vérifiable |
+|--------|----|---------------------|
+| 1 | US-100 | Schéma tenant + backfill, app inchangée |
+| 2–3 | US-101 | Couche services, non-régression complète |
+| 4 | US-102 | Isolation applicative + `_ask_question` scopé |
+| 5 | US-103 | RLS actif, test de fuite automatisé |
+| 6 | US-110, US-111 | Login web + liaison Telegram, bot fermé aux inconnus |
+| 7 | US-112, US-113 | Potager actif + rôles |
+| 8 | US-114 | Onboarding self-service de bout en bout |
+| 9 | US-121 | LLM à étages + parseur déterministe (peut démarrer dès sprint 2 en parallèle) |
+| 10 | US-120, US-122 | Redis + RAG scopé |
+| 11 | US-123, US-124 | Quotas tenant + jobs par potager |
+| 12 | US-125 | Alembic + CI/CD |
+| 13+ | US-130 → US-133 | Prod managée, observabilité, RGPD, Stripe |
+
+### Invariants à rappeler dans chaque US (règles de travail)
+
+1. Migration SQL toujours en fichier `migration_vX.sql` séparé (puis Alembic à partir de US-125), idempotente, avec rollback documenté.
+2. SQLAlchemy 2.0 : `db.get()`, jamais `db.query().get()`.
+3. Prompts Groq : `.replace()` sur les variables, jamais `.format()`.
+4. Logging structuré `HH:MM:SS │ LEVEL │ emoji MESSAGE` conservé partout.
+5. Tout nouvel appel Groq : impact tokens chiffré et loggé.
+6. Ordre critique des flux de conversation (modes `corr_*` > mode `ask` > NAV > `_is_question` > action) préservé ; tout refactor liste les effets de bord sur `ctx.user_data` / `ConversationState`.
+7. Échappement MarkdownV2 (underscores des parcelles, issue #21) dans toute nouvelle sortie bot.
+8. Compatible SentinelOne : polling Telegram côté dev local, pas de tunnel entrant.
+
+### Définition of Done commune
+
+- Tests de non-régression sur les 12 actions canoniques + flux correction + mode ask.
+- Test d'isolation inter-potagers (à partir de US-102) exécuté dans la CI.
+- `PATCH_NOTES.md` mis à jour.
+- Documentation de la migration et du rollback.

--- a/.github/agents/Personna PO.agent.md
+++ b/.github/agents/Personna PO.agent.md
@@ -81,10 +81,19 @@ Le fichier DOIT être nommé : `backlog/US-NNN_titre-court-kebab.md`
 - "Patcher", "appliquer", "déployer" quoi que ce soit
 - Chercher des alternatives si `createFiles` échoue (→ écrire dans le chat à la place)
 
+## Épics définis — noms exacts à recopier tels quels
+
+Si l'US rédigée appartient à l'un de ces épics (voir `BACKLOG_US_MULTITENANT.md`), recopie le nom **exactement** (il sert à assigner le Milestone GitHub correspondant) :
+- `ÉPIC 1 — Socle multi-tenant`
+- `ÉPIC 2 — Identité & accès`
+- `ÉPIC 3 — Fiabilité & coût`
+- `ÉPIC 4 — Commercialisation`
+
 ## Format de l'US
 
 **ID :** US-XXX  
 **Titre :** [verbe d'action + objet]
+**Épic :** [optionnel — uniquement si l'US appartient à un épic défini, ex: "ÉPIC 1 — Socle multi-tenant" ; omettre cette ligne pour une US indépendante]
 
 **Story :**
 En tant que [jardinier | administrateur]

--- a/.github/workflows/create-issues-from-backlog.yml
+++ b/.github/workflows/create-issues-from-backlog.yml
@@ -90,6 +90,49 @@ jobs:
               return labels;
             }
 
+            // PAGINATION : récupère TOUS les milestones existants du repo (ouverts + fermés)
+            async function getAllRepoMilestones() {
+              const milestones = [];
+              let page = 1;
+              while (true) {
+                const res = await github.rest.issues.listMilestones({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  state: 'all',
+                  per_page: 100,
+                  page
+                });
+                if (res.data.length === 0) break;
+                milestones.push(...res.data);
+                if (res.data.length < 100) break;
+                page++;
+              }
+              return milestones;
+            }
+
+            // Crée le milestone (épic) s'il n'existe pas encore, retourne son numéro
+            async function ensureMilestoneExists(epicTitle, repoMilestones) {
+              const match = repoMilestones.find(m => isSameLabel(m.title, epicTitle));
+              if (match) return match.number;
+
+              console.log(`   🎯 Création du milestone (épic): "${epicTitle}"`);
+              try {
+                const res = await github.rest.issues.createMilestone({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  title: epicTitle
+                });
+                repoMilestones.push(res.data);
+                return res.data.number;
+              } catch (err) {
+                if (err.status === 422) {
+                  const existing = repoMilestones.find(m => isSameLabel(m.title, epicTitle));
+                  return existing ? existing.number : null;
+                }
+                throw err;
+              }
+            }
+
             // CRÉATION de label manquant avec couleur selon catégorie
             function getLabelColor(label) {
               const n = normalize(label);
@@ -153,6 +196,14 @@ jobs:
                 .filter(l => l.length > 0);
             }
 
+            // EXTRACTION de l'épic depuis la ligne "**Épic :**" (optionnelle)
+            function extractEpic(content) {
+              const line = content.match(/\*\*Épic\s*:\*\*\s*(.+)/i);
+              if (!line) return null;
+              const epic = cleanLabel(line[1]).trim();
+              return epic.length > 0 ? line[1].trim() : null;
+            }
+
             // SUPPRIME le préfixe "US-XXX : " pour comparer avec les anciens titres
             function stripUsPrefix(title) {
               return title.replace(/^US-\d+\s*:\s*/i, '').trim();
@@ -170,12 +221,13 @@ jobs:
 
             // ── MAIN ──────────────────────────────────────────────────────────
 
-            console.log('Chargement des labels et issues existants...');
-            const [repoLabels, allIssues] = await Promise.all([
+            console.log('Chargement des labels, milestones et issues existants...');
+            const [repoLabels, repoMilestones, allIssues] = await Promise.all([
               getAllRepoLabels(),
+              getAllRepoMilestones(),
               getAllIssues()
             ]);
-            console.log(`${repoLabels.length} labels, ${allIssues.length} issues chargés.`);
+            console.log(`${repoLabels.length} labels, ${repoMilestones.length} milestones, ${allIssues.length} issues chargés.`);
 
             const backlogDir = './backlog';
             const files = fs.readdirSync(backlogDir)
@@ -201,29 +253,48 @@ jobs:
                 resolvedLabels.push(exactName);
               }
 
+              const epicTitle = extractEpic(content);
+              const milestoneNumber = epicTitle
+                ? await ensureMilestoneExists(epicTitle, repoMilestones)
+                : null;
+
               console.log(`\nFichier : ${file}`);
               console.log(`Titre   : ${title}`);
               console.log(`Labels  : ${resolvedLabels.join(', ')}`);
+              console.log(`Épic    : ${epicTitle || '(aucun)'}`);
 
               const existing = findExistingIssue(title, allIssues);
 
               if (existing) {
-                if (existing.title.trim() === title.trim()) {
+                const needsTitleUpdate = existing.title.trim() !== title.trim();
+                const currentMilestoneNumber = existing.milestone ? existing.milestone.number : null;
+                const needsMilestoneUpdate = milestoneNumber !== null && currentMilestoneNumber !== milestoneNumber;
+
+                if (!needsTitleUpdate && !needsMilestoneUpdate) {
                   console.log(`⏭ Issue #${existing.number} déjà à jour — ignorée.`);
-                } else {
-                  // Titre a changé (ex: ajout préfixe US-XXX) → mise à jour
-                  try {
-                    await github.rest.issues.update({
-                      owner: context.repo.owner,
-                      repo: context.repo.repo,
-                      issue_number: existing.number,
-                      title
-                    });
+                  continue;
+                }
+
+                const patch = {};
+                if (needsTitleUpdate) patch.title = title;
+                if (needsMilestoneUpdate) patch.milestone = milestoneNumber;
+
+                try {
+                  await github.rest.issues.update({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: existing.number,
+                    ...patch
+                  });
+                  if (needsTitleUpdate) {
                     console.log(`✏️ Issue #${existing.number} renommée : "${existing.title}" → "${title}"`);
-                    existing.title = title; // mise à jour locale
-                  } catch (err) {
-                    console.error(`❌ Erreur renommage #${existing.number}: ${err.message}`);
                   }
+                  if (needsMilestoneUpdate) {
+                    console.log(`🎯 Issue #${existing.number} assignée à l'épic "${epicTitle}"`);
+                  }
+                  existing.title = title; // mise à jour locale
+                } catch (err) {
+                  console.error(`❌ Erreur mise à jour #${existing.number}: ${err.message}`);
                 }
                 continue;
               }
@@ -234,6 +305,7 @@ jobs:
                   repo: context.repo.repo,
                   title,
                   body: content,
+                  milestone: milestoneNumber || undefined,
                   labels: resolvedLabels
                 });
                 console.log(`✅ Issue créée : #${issue.data.number}`);

--- a/BACKLOG_US_MULTITENANT.md
+++ b/BACKLOG_US_MULTITENANT.md
@@ -1,0 +1,236 @@
+# 🌿 Assistant Potager — Backlog US Multi-tenant & Sécurisation
+
+> **Document de référence pour Claude Code et l'agent de rédaction d'US.**
+> Objectif : solution 100 % multi-utilisateurs, sécurisée, prête à commercialisation.
+> Source : `REFLEXION_STRATEGIQUE_multi_utilisateurs.md` (§4 bloquants, §5 architecture cible, §7 trajectoire).
+> Convention : chaque US ci-dessous est à décliner au format `US-XXX` habituel (critères d'acceptance + Gherkin) par l'agent US, puis implémentée par l'agent d'implémentation.
+> Règle d'or transverse : **aucune US ne casse l'installation actuelle**. Les données existantes deviennent le potager #1.
+
+---
+
+## 0. Vue d'ensemble — ordre et dépendances
+
+```
+ÉPIC 1 — SOCLE TENANT          ÉPIC 2 — IDENTITÉ & ACCÈS      ÉPIC 3 — FIABILITÉ & COÛT      ÉPIC 4 — COMMERCIALISATION
+US-100 Modèle multi-tenant ──► US-110 Auth web (JWT)      ──► US-120 État Redis          ──► US-130 Postgres managé
+US-101 Couche services     ──► US-111 Liaison Telegram    ──► US-121 LLM à étages        ──► US-131 Observabilité
+US-102 Scoping requêtes    ──► US-112 Potager actif       ──► US-122 RAG scopé /ask      ──► US-132 RGPD
+US-103 RLS PostgreSQL      ──► US-113 Rôles & permissions ──► US-123 Quotas par tenant   ──► US-133 Stripe / freemium
+                               US-114 Invitations         ──► US-124 Jobs par potager
+                                                              US-125 Alembic + CI/CD
+```
+
+**Chemin critique :** `US-100 → US-101 → US-102 → US-103 → US-110 → US-111 → US-113`.
+Tout le reste peut être parallélisé une fois son épic amont livré.
+
+**Chantier parallèle (hors périmètre de ce backlog, à ne pas oublier) :** la base de connaissance *fiches cultures* (`US_Base_fiches_cultures`), qui conditionne la valeur produit de l'offre payante. À mener en parallèle des épics 1–2, car sans elle on commercialise « un carnet multi-utilisateurs », facilement copiable.
+
+---
+
+## ÉPIC 1 — Socle multi-tenant (Phase 0–1 de la trajectoire)
+
+### US-100 — Modèle multi-tenant (users / potagers / membres)
+
+- **Contexte :** aucune notion de tenant aujourd'hui ; tables globales. Bloquant #1.
+- **Objectif :** créer le socle de données du tenant **potager** (pas l'utilisateur — 500 users / 100 potagers ≈ 5 personnes/jardin, les jardins sont partagés).
+- **Périmètre :**
+  - Tables `users (id, email, telegram_chat_id UNIQUE NULL, cree_le)`, `potagers (id, nom, latitude, longitude, proprietaire_id FK users, cree_le)`, `potager_membres (user_id, potager_id, role CHECK IN ('owner','editor','lecteur'), PRIMARY KEY (user_id, potager_id))`.
+  - Ajout `potager_id INTEGER NULL REFERENCES potagers(id)` sur **toutes** les tables métier : `evenements`, `parcelles`, `culture_config`, et toute table dérivée.
+  - Backfill : création du user #1 (Emmanuel, chat_id actuel), du potager #1 (localisation actuelle), rattachement owner, `UPDATE ... SET potager_id = 1` sur toutes les lignes existantes.
+  - Index : `CREATE INDEX ... ON evenements (potager_id, date DESC)` (et équivalent sur les autres tables).
+- **Hors périmètre :** aucun changement de comportement du bot ; les colonnes restent nullables à ce stade.
+- **Migration :** `migration_v5.sql` complet, rejouable (idempotent : `IF NOT EXISTS`), exécutable via `psql`.
+- **Critères d'acceptance clés :** bot et PWA fonctionnent à l'identique après migration ; `SELECT count(*) FROM evenements WHERE potager_id IS NULL` = 0 après backfill ; rollback documenté.
+- **Impact tokens :** nul. **Risques :** oubli d'une table dérivée → inventorier via `information_schema` dans l'US.
+
+### US-101 — Couche `services/` partagée bot ⇄ PWA
+
+- **Contexte :** logique métier éclatée entre `bot.py` (~1300 lignes) et `main.py`. Si l'isolation est codée deux fois, elle sera fausse une fois.
+- **Objectif :** extraire la logique métier dans `app/services/` ; chaque fonction de service prend **obligatoirement** un contexte `TenantContext(user_id, potager_id, role)`. Bot et FastAPI deviennent des clients minces.
+- **Périmètre :** modules suggérés : `services/evenements.py` (CRUD + corrections), `services/stats.py`, `services/stock.py`, `services/plan.py`, `services/questions.py` (`_ask_question`). Signature type : `def enregistrer_evenement(ctx: TenantContext, data: EvenementIn) -> Evenement`.
+- **Hors périmètre :** pas encore de vérification des rôles (US-113) ; `ctx` peut être construit avec le potager #1 en dur pendant la transition.
+- **Critères d'acceptance clés :** aucun `db.query(Evenement)` ne subsiste dans `bot.py` / `main.py` ; comportement identique (tests de non-régression sur les 12 actions canoniques + flux `corr_*` + mode `ask`) ; logging structuré `HH:MM:SS │ LEVEL │ emoji` conservé.
+- **Risques / effets de bord :** refactor massif → découper en sous-US par module ; attention aux états `ctx.user_data` (Telegram) qui ne migrent PAS dans services (ils restent côté client bot jusqu'à US-120). SQLAlchemy 2.0 : `db.get()`, jamais `db.query().get()`.
+
+### US-102 — Scoping systématique par `potager_id` (dont refonte `_ask_question`)
+
+- **Contexte :** `_ask_question()` charge tout l'historique sans filtre (~5 000 tokens) : fuite inter-potagers + explosion de coût + débordement de contexte. Limiter à 100 événements ne suffit pas : il faut **scoper avant de limiter**.
+- **Objectif :** toute requête de la couche services filtre par `ctx.potager_id`. Zéro requête non scopée dans le code applicatif.
+- **Périmètre :**
+  - Filtre `potager_id` dans tous les services (lecture, écriture, correction, suppression, stats, stock, plan, rotation).
+  - `_ask_question` : scope potager + fenêtre temporelle (défaut 12 mois) + limite (100 événements max) ; sérialisation compacte.
+  - `potager_id` devient `NOT NULL` sur toutes les tables métier (`migration_v6.sql`).
+- **Critères d'acceptance clés (Gherkin type) :** *Étant donné* deux potagers A et B avec des événements, *quand* un membre de A demande stats/historique/question, *alors* aucune donnée de B n'apparaît. Test automatisé d'isolation obligatoire.
+- **Impact tokens :** `_ask_question` passe de ~5 000 à < 1 500 tokens/appel (à mesurer et logger).
+- **Risques :** requêtes brutes SQL éventuelles (stats) à auditer une par une.
+
+### US-103 — Row-Level Security PostgreSQL (défense en profondeur)
+
+- **Contexte :** même avec le scoping applicatif, un bug suffit pour fuir. Ceinture + bretelles.
+- **Objectif :** policies RLS garantissant qu'aucune requête ne sort du potager courant, même en cas de bug applicatif.
+- **Périmètre :**
+  - Rôle applicatif Postgres non-superuser (RLS ne s'applique pas au owner de table → créer `app_user`).
+  - `ALTER TABLE ... ENABLE ROW LEVEL SECURITY` + policy `USING (potager_id = current_setting('app.potager_id')::int)` sur chaque table métier.
+  - Dans `db.py` : à l'ouverture de session, `SET LOCAL app.potager_id = :pid` (event SQLAlchemy `after_begin` ou context manager de session tenant-aware).
+- **Migration :** `migration_v7.sql` (policies) + modification `database/db.py`.
+- **Critères d'acceptance clés :** une requête volontairement non scopée (test dédié) retourne 0 ligne d'un autre potager ; les migrations/backups (rôle admin) restent possibles.
+- **Risques :** oubli du `SET` → requêtes qui retournent 0 ligne partout (échec silencieux) : prévoir un fail-fast si `app.potager_id` absent ; jobs de fond (US-124) devront itérer en posant le setting par potager.
+
+---
+
+## ÉPIC 2 — Identité & accès (Phase 2–3)
+
+### US-110 — Authentification web (inscription + login JWT)
+
+- **Objectif :** identité e-mail/mot de passe pour la PWA ; tous les endpoints FastAPI protégés.
+- **Périmètre :** hash mot de passe (argon2 ou bcrypt via `passlib`) ; JWT access (15 min) + refresh (30 j) ; endpoints `/auth/register`, `/auth/login`, `/auth/refresh` ; dépendance FastAPI `get_current_user` appliquée à **tous** les endpoints métier ; construction du `TenantContext` depuis le JWT. Rate-limit basique sur `/auth/*`.
+- **Hors périmètre :** OAuth Google (évolution ultérieure), reset mot de passe par e-mail (peut être une sous-US si l'envoi d'e-mail n'est pas encore disponible).
+- **Critères d'acceptance clés :** endpoint sans token → 401 ; token expiré → 401 + refresh fonctionne ; mot de passe jamais loggé ni stocké en clair ; secrets (JWT_SECRET) via variables d'environnement, pas dans `config.py` versionné.
+- **Risques :** la PWA actuelle appelle l'API sans auth → coordonner front/back dans la même US.
+
+### US-111 — Liaison Telegram ⇄ compte web par code à usage unique
+
+- **Objectif :** rattacher un `chat_id` Telegram à un compte web. Un compte = un web + un Telegram liés.
+- **Périmètre :** génération d'un code court (6–8 caractères, TTL 10 min, usage unique) côté web ; commande `/lier <code>` (et détection du code en message texte) côté bot ; écriture `users.telegram_chat_id` ; le bot **refuse tout message d'un `chat_id` non lié** (message d'onboarding avec lien vers l'inscription).
+- **Critères d'acceptance clés :** code expiré/déjà utilisé → refus explicite ; un `chat_id` ne peut être lié qu'à un seul compte ; un chat inconnu ne peut déclencher **aucun** appel Groq (économie + sécurité).
+- **Effets de bord :** `handle_voice`/`handle_text` doivent vérifier la liaison **avant** toute transcription Whisper — placer le garde en tout premier dans le flux (avant les priorités 1–5).
+
+### US-112 — Sélection du potager actif
+
+- **Objectif :** un utilisateur peut appartenir à plusieurs potagers → notion de potager actif, stocké par utilisateur, côté web et Telegram.
+- **Périmètre :** colonne `users.potager_actif_id` (ou table de préférences) ; commande `/potager` avec boutons inline listant les potagers du membre ; sélecteur équivalent dans la PWA ; le `TenantContext` est construit depuis le potager actif ; si un seul potager → sélection automatique silencieuse.
+- **Critères d'acceptance clés :** après changement de potager actif, toutes les saisies/questions portent sur le nouveau potager ; utilisateur sans potager → invité à en créer un (lien avec US-114).
+- **Migration :** incluse dans `migration_v8.sql` avec US-111 si livrées ensemble.
+
+### US-113 — Rôles & permissions (owner / editor / lecteur)
+
+- **Objectif :** contrôle d'accès par rôle, écrit **une seule fois** dans la couche services.
+- **Périmètre :** matrice : `lecteur` = consultation (stats, historique, questions) ; `editor` = + saisie/correction/suppression d'événements ; `owner` = + gestion des membres, paramètres du potager, suppression du potager. Décorateur ou garde `require_role(ctx, 'editor')` dans chaque service d'écriture. Messages d'erreur clairs côté bot et PWA (« Tu es lecteur sur ce potager »).
+- **Critères d'acceptance clés (Gherkin type) :** *Étant donné* un lecteur, *quand* il dicte « j'ai récolté 2 kg de tomates », *alors* rien n'est enregistré et un message d'explication est renvoyé (et l'appel de parsing LLM n'a **pas lieu** — vérifier le rôle avant `parse_actions`).
+- **Impact tokens :** positif (blocage avant appel LLM pour les lecteurs).
+
+### US-114 — Invitations & onboarding self-service
+
+- **Objectif :** plus aucune opération manuelle pour créer un utilisateur ou un potager.
+- **Périmètre :** création de potager depuis la PWA (nom + localisation — la géolocalisation alimente la météo par potager, US-124) ; invitation de membre par e-mail ou lien/code d'invitation avec rôle proposé ; acceptation → insertion dans `potager_membres` ; parcours complet documenté : inscription → création/adhésion potager → liaison Telegram → première saisie.
+- **Critères d'acceptance clés :** un nouvel utilisateur atteint sa première saisie vocale sans aucune intervention de l'administrateur ; l'owner peut retirer un membre ; un membre retiré perd l'accès immédiatement (invalidation du potager actif).
+
+---
+
+## ÉPIC 3 — Fiabilité & maîtrise du coût (Phase 4) — *condition de survie économique*
+
+### US-120 — État conversationnel persistant (Redis)
+
+- **Contexte :** flux `corr_*` et mode `ask` en RAM (`ctx.user_data`) → perdus au redémarrage, non partageables, non scalables.
+- **Objectif :** état des conversations dans Redis, clé `state:{user_id}`, TTL (ex. 15 min), sérialisation JSON.
+- **Périmètre :** wrapper `ConversationState` (get/set/clear) remplaçant les accès `ctx.user_data` pour les modes ; docker-compose ajoute Redis ; fallback dégradé si Redis indisponible (mode sans état + log ERROR).
+- **Critères d'acceptance clés :** redémarrage du bot en plein flux `corr_select` → le flux reprend ; TTL expiré → retour au menu proprement.
+- **Risques / effets de bord :** c'est LE refactor sensible sur les états — tester les 5 priorités de `handle_text` et le bypass vocal ; conserver l'ordre critique (modes corr > ask > NAV > question > action).
+
+### US-121 — LLM à étages + parsing déterministe + cache
+
+- **Contexte :** goulot n°1 du projet = tokens Groq, pas l'infra.
+- **Objectif :** réduire drastiquement le coût par message.
+- **Périmètre :**
+  1. `classify_intent()` → `llama-3.1-8b-instant` (~×9 d'économie), 70B réservé au parsing structuré.
+  2. Parseur déterministe (regex/grammaire) **avant** tout appel LLM pour les formes fréquentes (« récolté 2 kg de tomates », « semé 3 rangs de carottes parcelle nord ») → zéro token sur ces cas ; le LLM devient le fallback.
+  3. Cache de classification (Redis, clé = hash du texte normalisé, TTL 24 h) pour les phrases courtes identiques.
+  4. Log du nombre de tokens consommés par appel (colonne ou log structuré) pour mesurer.
+- **Critères d'acceptance clés :** jeu de tests de non-régression sur un corpus de phrases réelles (extraites de `texte_original`) : le parseur déterministe couvre ≥ 50 % des saisies sans dégrader la précision ; taux d'erreur d'intent mesuré avant/après bascule 8B.
+- **Impact tokens :** cible 🔶 : coût moyen/message divisé par 5 à 10. **Risques :** le 8B classe moins bien → garder un fallback 70B si confiance faible ; ne pas oublier `.replace()` (jamais `.format()`) dans les prompts.
+
+### US-122 — RAG scopé et pré-agrégé pour les questions (`/ask`)
+
+- **Contexte :** complément de US-102 : après le scoping, optimiser la *qualité/coût* des réponses.
+- **Objectif :** ne jamais envoyer de lignes brutes massives au LLM ; pré-agréger en SQL, nourrir le LLM avec des résumés.
+- **Périmètre :** classification légère de la question (culture ? période ? type de question ?) ; requêtes SQL d'agrégation ciblées (totaux par culture/mois, dernières occurrences) ; contexte final < 1 000 tokens ; fenêtre temporelle adaptative selon la question.
+- **Critères d'acceptance clés :** corpus de questions réelles → réponses correctes avec contexte < 1 000 tokens ; aucune donnée hors `potager_id`.
+- **Impact tokens :** ~5 000 → < 1 500 par question (mesuré).
+
+### US-123 — Quotas tokens & rate-limiting par tenant
+
+- **Contexte :** quota Groq global partagé = non viable ; le prix de l'offre doit couvrir le coût réel/user/mois.
+- **Objectif :** comptabiliser et plafonner la consommation par potager.
+- **Périmètre :** table `conso_tokens (potager_id, date, appel_type, modele, tokens_in, tokens_out)` alimentée par un wrapper unique autour du client Groq ; budget quotidien/mensuel par potager (colonne `potagers.plan` : free/payant) ; dépassement → message clair + blocage des appels LLM (les fonctions déterministes restent disponibles) ; rate-limit par user (ex. N messages/minute) ; endpoint/commande de consultation de conso.
+- **Critères d'acceptance clés :** potager au quota → saisies simples via parseur déterministe encore possibles, questions LLM bloquées avec message d'upgrade ; tableau de conso par potager consultable (base du pricing).
+- **Dépendances :** US-121 (wrapper Groq unique).
+
+### US-124 — Jobs de fond par potager (météo, sauvegardes, alertes)
+
+- **Contexte :** météo mono-localisation, job global 5h, aucune sauvegarde automatique.
+- **Objectif :** ordonnanceur qui itère sur les potagers.
+- **Périmètre :** APScheduler (Celery/RQ seulement si ça grossit) ; job météo par `(lat, lon)` distinct avec cache `(lat, lon, jour)` et batching Open-Meteo ; alertes gel/canicule envoyées aux membres du potager concerné via Telegram ; job de sauvegarde quotidien (`pg_dump` + rétention 30 j) tant que US-130 n'est pas livrée ; chaque job pose `app.potager_id` (compatibilité RLS, cf. US-103).
+- **Critères d'acceptance clés :** 2 potagers à localisations différentes reçoivent des météos différentes ; échec d'un job pour un potager n'interrompt pas les autres (isolation d'erreurs + log).
+
+### US-125 — Migrations Alembic + CI/CD
+
+- **Contexte :** migrations jouées à la main → intenable en prod multi-tenant vivante.
+- **Objectif :** migrations versionnées et déploiement reproductible.
+- **Périmètre :** init Alembic + reprise de l'état actuel comme révision de base (les `migration_vX.sql` historiques restent en archive) ; docker-compose (FastAPI + bot + Redis) ; GitHub Actions : tests → build → déploiement Scaleway → `alembic upgrade head` → restart services ; secrets en variables d'environnement/GitHub Secrets.
+- **Critères d'acceptance clés :** un `git push` sur `main` déploie sans intervention manuelle et sans coupure perceptible ; rollback de migration documenté et testé.
+
+---
+
+## ÉPIC 4 — Commercialisation (Phase 5)
+
+### US-130 — PostgreSQL managé + sauvegardes automatiques
+
+- **Périmètre :** migration vers Postgres managé Scaleway (sauvegardes auto, PITR) ; bascule `DATABASE_URL` ; répétition générale de la migration sur une copie ; fenêtre de coupure planifiée et courte.
+- **Critères d'acceptance clés :** restauration testée réellement (pas seulement des backups qui existent) ; latence applicative inchangée.
+
+### US-131 — Observabilité
+
+- **Périmètre :** Sentry (bot + API) ; logs centralisés ; métriques : messages/jour, erreurs, latence Groq, **tokens par tenant** (réutilise US-123) ; alerte si taux d'erreur anormal ou quota Groq global proche de la limite.
+- **Critères d'acceptance clés :** une exception non gérée en prod apparaît dans Sentry avec contexte (user_id, potager_id — sans données personnelles sensibles).
+
+### US-132 — RGPD & conformité
+
+- **Contexte :** pré-requis légal de commercialisation dès qu'il y a des données de tiers.
+- **Périmètre :** export des données du compte (JSON/CSV) ; suppression de compte (et anonymisation des événements d'un potager partagé : l'événement reste, l'auteur est anonymisé) ; consentement à l'inscription ; CGU + politique de confidentialité + mentions légales ; registre des traitements (document) ; TTL sur les fichiers audio temporaires (les vocaux ne sont pas conservés après transcription).
+- **Critères d'acceptance clés :** suppression de compte → plus aucune donnée personnelle en base (vérification par requête) ; export complet en < 1 min.
+- **Risques :** cas du dernier owner d'un potager qui supprime son compte → règle à définir dans l'US (transfert ou suppression du potager).
+
+### US-133 — Facturation Stripe (freemium)
+
+- **Périmètre :** plans free (quota tokens limité, 1 potager) / payant (quotas supérieurs, potagers multiples, fonctions premium — ex. prévision de récolte, diagnostic photo) ; Stripe Checkout + webhooks (paiement, échec, résiliation) ; `potagers.plan` piloté par l'abonnement ; page de gestion d'abonnement.
+- **Critères d'acceptance clés :** cycle complet testé en mode test Stripe : souscription → upgrade quota effectif → résiliation → retour au plan free en fin de période.
+- **Dépendances :** US-123 (quotas), US-132 (CGU obligatoires avant encaissement). **Pré-requis business :** mesurer 1 mois de conso réelle (US-123) pour fixer un prix couvrant le coût Groq/user/mois.
+
+---
+
+## Annexes pour l'agent US
+
+### Ordre de livraison recommandé (sprints indicatifs)
+
+| Sprint | US | Livrable vérifiable |
+|--------|----|---------------------|
+| 1 | US-100 | Schéma tenant + backfill, app inchangée |
+| 2–3 | US-101 | Couche services, non-régression complète |
+| 4 | US-102 | Isolation applicative + `_ask_question` scopé |
+| 5 | US-103 | RLS actif, test de fuite automatisé |
+| 6 | US-110, US-111 | Login web + liaison Telegram, bot fermé aux inconnus |
+| 7 | US-112, US-113 | Potager actif + rôles |
+| 8 | US-114 | Onboarding self-service de bout en bout |
+| 9 | US-121 | LLM à étages + parseur déterministe (peut démarrer dès sprint 2 en parallèle) |
+| 10 | US-120, US-122 | Redis + RAG scopé |
+| 11 | US-123, US-124 | Quotas tenant + jobs par potager |
+| 12 | US-125 | Alembic + CI/CD |
+| 13+ | US-130 → US-133 | Prod managée, observabilité, RGPD, Stripe |
+
+### Invariants à rappeler dans chaque US (règles de travail)
+
+1. Migration SQL toujours en fichier `migration_vX.sql` séparé (puis Alembic à partir de US-125), idempotente, avec rollback documenté.
+2. SQLAlchemy 2.0 : `db.get()`, jamais `db.query().get()`.
+3. Prompts Groq : `.replace()` sur les variables, jamais `.format()`.
+4. Logging structuré `HH:MM:SS │ LEVEL │ emoji MESSAGE` conservé partout.
+5. Tout nouvel appel Groq : impact tokens chiffré et loggé.
+6. Ordre critique des flux de conversation (modes `corr_*` > mode `ask` > NAV > `_is_question` > action) préservé ; tout refactor liste les effets de bord sur `ctx.user_data` / `ConversationState`.
+7. Échappement MarkdownV2 (underscores des parcelles, issue #21) dans toute nouvelle sortie bot.
+8. Compatible SentinelOne : polling Telegram côté dev local, pas de tunnel entrant.
+
+### Définition of Done commune
+
+- Tests de non-régression sur les 12 actions canoniques + flux correction + mode ask.
+- Test d'isolation inter-potagers (à partir de US-102) exécuté dans la CI.
+- `PATCH_NOTES.md` mis à jour.
+- Documentation de la migration et du rollback.

--- a/US-100_modele_multitenant.md
+++ b/US-100_modele_multitenant.md
@@ -1,0 +1,78 @@
+# US-100 : Modèle multi-tenant (users / potagers / membres)
+
+**Titre :** Créer le socle de données multi-tenant avec backfill des données existantes vers le potager #1
+
+**Story :**
+En tant qu'administrateur de la plateforme
+Je veux que chaque donnée métier soit rattachée à un potager (le tenant) via un modèle users / potagers / potager_membres
+Afin de préparer l'isolation des données entre jardins sans casser l'installation actuelle
+
+---
+
+**Critères d'acceptance :**
+
+- [ ] CA1 : Une table `users` existe avec les colonnes `id SERIAL PK`, `email VARCHAR(255) UNIQUE NULL`, `telegram_chat_id BIGINT UNIQUE NULL`, `nom VARCHAR(100)`, `cree_le TIMESTAMP DEFAULT now()`
+- [ ] CA2 : Une table `potagers` existe avec `id SERIAL PK`, `nom VARCHAR(100) NOT NULL`, `latitude FLOAT`, `longitude FLOAT`, `proprietaire_id INTEGER NOT NULL REFERENCES users(id)`, `plan VARCHAR(20) DEFAULT 'free'`, `cree_le TIMESTAMP DEFAULT now()`
+- [ ] CA3 : Une table `potager_membres` existe avec `user_id INTEGER REFERENCES users(id)`, `potager_id INTEGER REFERENCES potagers(id)`, `role VARCHAR(10) NOT NULL CHECK (role IN ('owner','editor','lecteur'))`, `PRIMARY KEY (user_id, potager_id)`
+- [ ] CA4 : Toutes les tables métier (`evenements`, `culture_config`, et toute autre table métier détectée via `information_schema.tables`) portent une colonne `potager_id INTEGER NULL REFERENCES potagers(id)` — **nullable à ce stade** (le passage NOT NULL est réservé à US-102)
+- [ ] CA5 : Le backfill crée le user #1 (nom "Emmanuel", `telegram_chat_id` = valeur du chat_id actuel lue depuis une variable de migration), le potager #1 (nom "Potager principal", latitude/longitude actuelles du job météo), le lien membre (user #1, potager #1, 'owner'), puis met à jour **100 % des lignes** de toutes les tables métier avec `potager_id = 1`
+- [ ] CA6 : Un index composite `(potager_id, date DESC)` existe sur `evenements` ; un index `(potager_id)` existe sur chaque autre table métier
+- [ ] CA7 : Les modèles SQLAlchemy (`database/models.py`) sont mis à jour : classes `User`, `Potager`, `PotagerMembre` + attribut `potager_id` sur `Evenement` (et autres modèles) — **sans modifier aucune requête existante** dans `bot.py` / `main.py`
+- [ ] CA8 : La migration est idempotente (`IF NOT EXISTS` / `WHERE potager_id IS NULL`) : la rejouer deux fois ne produit ni erreur ni doublon
+- [ ] CA9 : Un script de rollback `migrations/rollback_v6.sql` supprime colonnes, index et tables dans l'ordre inverse des dépendances FK
+- [ ] CA10 : Après migration, le bot et la PWA fonctionnent **strictement à l'identique** : les 12 actions canoniques, les flux `corr_*`, le mode `ask`, `/stats`, `/plan` passent les tests de non-régression sans modification de comportement
+
+**Notes fonctionnelles :**
+- Zone fonctionnelle concernée : base de données + modèles (aucun changement d'interaction Telegram ni PWA)
+- Migration BDD requise : **oui** — `migrations/migration_v6.sql` ⚠️ vérifier la dernière version existante dans `migrations/` avant création (v5 = culture_config / US-001)
+- Dépendances : aucune (première US de l'épic multi-tenant ; US-101, US-102, US-103 en dépendent)
+- Zéro token Groq : aucune modification des appels LLM
+- Invariants projet : SQLAlchemy 2.0 (`db.get()`), migration en fichier séparé exécutable via `psql`, pas d'`ALTER TABLE` inline dans le code Python, `PATCH_NOTES.md` à mettre à jour
+
+**Notes techniques (pour Persona Developer) :**
+- Composants impactés : `migrations/migration_v6.sql` (nouveau), `migrations/rollback_v6.sql` (nouveau), `database/models.py`
+- Le `telegram_chat_id` et les coordonnées du potager #1 sont fournis en tête de migration sous forme de variables psql (`\set chat_id ...`) ou d'un bloc `DO $$` documenté — pas de valeur en dur non commentée
+- Inventaire des tables métier : lister via `SELECT table_name FROM information_schema.tables WHERE table_schema='public'` et documenter dans la migration la liste exacte des tables modifiées (commentaire SQL) pour audit ultérieur par US-102
+- Ne PAS ajouter `potager_id` aux tables système/référentiel pur si non pertinent — décision à documenter table par table (ex. `culture_config` : si le référentiel devient personnalisable par potager, il prend `potager_id` nullable où NULL = fiche globale partagée ; c'est l'option retenue)
+
+**Estimation :** 3 points
+
+**Scénario Gherkin :**
+```gherkin
+Feature: Socle de données multi-tenant
+
+  Scenario: Migration v6 appliquée sur la base de production existante
+    Given une base de données en version v5 contenant des événements existants
+    When la migration migration_v6.sql est exécutée via psql
+    Then les tables users, potagers et potager_membres existent
+    And la colonne potager_id existe sur evenements et culture_config
+    And aucune donnée existante n'est perdue
+
+  Scenario: Backfill complet vers le potager #1
+    Given la migration v6 est appliquée
+    When le bloc de backfill s'exécute
+    Then le user #1 existe avec le telegram_chat_id actuel
+    And le potager #1 existe avec les coordonnées météo actuelles
+    And potager_membres contient (user #1, potager #1, 'owner')
+    And SELECT count(*) FROM evenements WHERE potager_id IS NULL retourne 0
+
+  Scenario: Idempotence de la migration
+    Given la migration v6 a déjà été appliquée avec succès
+    When migration_v6.sql est rejouée
+    Then aucune erreur n'est levée
+    And aucun user, potager ou membre en doublon n'est créé
+
+  Scenario: Non-régression du bot après migration
+    Given la migration v6 est appliquée et le bot redémarré
+    When le jardinier dicte "j'ai récolté 2 kg de tomates"
+    Then l'événement est enregistré comme avant la migration
+    And les commandes /stats, /plan et le mode ask répondent à l'identique
+
+  Scenario: Rollback
+    Given la migration v6 est appliquée
+    When rollback_v6.sql est exécuté
+    Then les colonnes potager_id, les index et les tables users, potagers, potager_membres sont supprimés
+    And la base est fonctionnellement identique à la version v5
+```
+
+**Labels GitHub :** `us`, `sprint-1`, `database`, `multi-tenant`, `fondation`

--- a/backlog/US-044_authentification-web-jwt.md
+++ b/backlog/US-044_authentification-web-jwt.md
@@ -1,0 +1,69 @@
+**ID :** US-044
+**Titre :** Authentifier les utilisateurs de la PWA par e-mail / mot de passe (JWT)
+**Épic :** ÉPIC 2 — Identité & accès
+
+**Story :**
+En tant qu'utilisateur de la Progressive Web App
+Je veux créer un compte et me connecter avec un e-mail et un mot de passe
+Afin que mes données de potager ne soient accessibles qu'à moi et aux personnes que j'autorise
+
+**Contexte fonctionnel :**
+Aujourd'hui, la PWA appelle l'API FastAPI sans aucune authentification : tout appelant peut lire/écrire les données de n'importe quel potager. Cette US introduit l'identité web (distincte du bot Telegram, traité en US-045) : inscription, connexion, et un jeton JWT vérifié sur tous les endpoints métier. C'est le point d'entrée obligatoire de l'ÉPIC 2 — sans lui, aucune notion de rôle (US-047) ni de potager actif (US-046) n'a de support.
+
+**Critères d'acceptance :**
+- [ ] CA1 : Un utilisateur peut s'inscrire via `POST /auth/register` avec e-mail + mot de passe ; le mot de passe est haché (argon2 ou bcrypt via `passlib`), jamais stocké ni loggé en clair
+- [ ] CA2 : Un utilisateur inscrit peut se connecter via `POST /auth/login` et reçoit un access token JWT (durée de vie 15 min) et un refresh token (durée de vie 30 jours)
+- [ ] CA3 : `POST /auth/refresh` permet d'obtenir un nouvel access token à partir d'un refresh token valide, sans redemander le mot de passe
+- [ ] CA4 : Une dépendance FastAPI `get_current_user` est appliquée à **tous** les endpoints métier existants (`/parse`, `/ask`, `/stats`, `/historique`, `/cultures`, etc.) — un appel sans token valide renvoie `401`
+- [ ] CA5 : Un token expiré renvoie `401` de façon explicite (code d'erreur distinct d'un token absent, pour permettre au front de déclencher le refresh automatiquement)
+- [ ] CA6 : Le secret de signature JWT (`JWT_SECRET`) est lu depuis une variable d'environnement (`.env.dev` / `.env.prod`), jamais codé en dur ni versionné
+- [ ] CA7 : Une tentative de réutilisation d'un e-mail déjà inscrit sur `/auth/register` renvoie une erreur explicite (409), sans révéler si l'e-mail existe déjà de façon exploitable pour de l'énumération de comptes
+- [ ] CA8 : Un rate-limit basique est actif sur `/auth/login` et `/auth/register` (ex. N tentatives/minute par IP) pour limiter le brute-force
+
+**Notes fonctionnelles :**
+- Zone fonctionnelle concernée : PWA (nouveaux écrans inscription/connexion) + API (nouveaux endpoints `/auth/*` + garde sur les endpoints existants)
+- Migration BDD requise : **oui** — ajout des colonnes de credentials sur la table `users` créée en US-040 (`mot_de_passe_hash`, éventuellement `email_verifie`), migration numérotée (vérifier le dernier numéro au moment de l'implémentation)
+- Dépendances : US-040 (table `users`), US-041 (couche services — `TenantContext` doit pouvoir être construit depuis un `user_id` authentifié plutôt qu'en dur)
+- Zéro impact tokens Groq
+- Invariants projet : migration en fichier séparé idempotent avec rollback documenté ; secrets via variables d'environnement uniquement
+
+**Notes techniques (pour Persona Developer) :**
+- Composants impactés : nouveau module `services/auth.py` (ou `app/auth/`), nouveaux endpoints dans `main.py`, migration SQL, dépendances `passlib`, `python-jose` (ou équivalent) à ajouter à `requirements.txt`
+- Hors périmètre explicite de cette US : OAuth Google, réinitialisation de mot de passe par e-mail (sous-US ultérieure si l'envoi d'e-mail transactionnel n'est pas encore en place), vérification d'e-mail à l'inscription
+- Le `TenantContext` (introduit en US-041) doit être construit à partir du `user_id` extrait du JWT — cette US ne construit pas encore le `potager_id` du contexte (potager actif géré en US-046) ; prévoir une valeur temporaire ou un état "sans potager actif" en sortie de login tant que US-046 n'est pas livrée
+- Coordonner précisément le front (appel `/auth/*`, stockage du token, intercepteur de refresh) et le back dans la même US pour éviter une PWA qui casse en production
+
+**Estimation :** 8 points
+
+**Scénario Gherkin :**
+```gherkin
+Scénario: Inscription réussie
+  Given aucun compte n'existe pour l'e-mail "jardinier@example.com"
+  When l'utilisateur s'inscrit avec cet e-mail et un mot de passe valide
+  Then un compte est créé
+  And le mot de passe n'est jamais stocké en clair
+
+Scénario: Connexion réussie
+  Given un compte existant avec e-mail et mot de passe
+  When l'utilisateur se connecte avec les identifiants corrects
+  Then il reçoit un access token et un refresh token
+
+Scénario: Accès refusé sans token
+  Given aucun token n'est fourni
+  When un appel est fait à un endpoint métier protégé (ex. /historique)
+  Then la réponse est 401
+
+Scénario: Token expiré puis rafraîchi
+  Given un access token expiré et un refresh token valide
+  When l'utilisateur appelle un endpoint protégé avec le token expiré
+  Then la réponse est 401
+  When l'utilisateur appelle /auth/refresh avec le refresh token
+  Then il reçoit un nouvel access token valide
+
+Scénario: Double inscription refusée
+  Given un compte existe déjà pour "jardinier@example.com"
+  When une nouvelle inscription est tentée avec le même e-mail
+  Then la réponse est 409 sans détail exploitable pour énumérer les comptes
+```
+
+**Labels GitHub :** `us`, `sprint-identite-acces`, `api`, `security`, `multi-tenant`, `pwa`

--- a/backlog/US-045_liaison-telegram-compte-web.md
+++ b/backlog/US-045_liaison-telegram-compte-web.md
@@ -1,0 +1,69 @@
+**ID :** US-045
+**Titre :** Lier un chat Telegram à un compte web par code à usage unique
+**Épic :** ÉPIC 2 — Identité & accès
+
+**Story :**
+En tant qu'utilisateur ayant créé un compte sur la PWA
+Je veux rattacher mon compte Telegram à ce compte web via un code à usage unique
+Afin que mes messages vocaux et texte envoyés au bot soient rattachés à mon identité et à mes potagers, et non traités anonymement
+
+**Contexte fonctionnel :**
+Depuis US-044, la PWA a une identité (e-mail/mot de passe). Le bot Telegram, lui, n'identifie encore ses interlocuteurs que par `chat_id` sans lien avec un compte. Cette US crée le pont : un code court généré côté web est saisi côté Telegram pour lier `telegram_chat_id` à un `user_id`. Une fois cette US livrée, le bot doit refuser tout message provenant d'un `chat_id` non lié — condition nécessaire avant d'activer les rôles (US-047), sans quoi un chat non identifié pourrait continuer à écrire des données sans propriétaire clair.
+
+**Critères d'acceptance :**
+- [ ] CA1 : La PWA (utilisateur connecté) peut générer un code court (6 à 8 caractères, alphanumérique non ambigu), affiché à l'écran avec un TTL de 10 minutes
+- [ ] CA2 : Dans Telegram, la commande `/lier <code>` (et la détection du code seul envoyé en message texte) valide le code et écrit `users.telegram_chat_id` pour le compte correspondant
+- [ ] CA3 : Un code expiré (> 10 min) est refusé avec un message explicite invitant à en régénérer un depuis la PWA
+- [ ] CA4 : Un code déjà utilisé est refusé avec un message explicite (usage unique strict)
+- [ ] CA5 : Un `chat_id` ne peut être lié qu'à un seul compte à la fois ; une tentative de liaison d'un `chat_id` déjà lié à un autre compte est refusée avec message explicite (proposer une procédure de déliaison, hors périmètre technique de cette US si elle nécessite une action de support)
+- [ ] CA6 : Tout message (vocal ou texte) reçu d'un `chat_id` non lié à un compte déclenche un message d'onboarding (lien vers l'inscription web + explication de la commande `/lier`) et **n'entraîne aucun appel Groq** (ni transcription Whisper, ni classification d'intent)
+- [ ] CA7 : Le garde de vérification de liaison est positionné en tout premier dans `handle_voice` et `handle_text`, avant toute autre logique (priorité 0, avant les priorités 1 à 5 existantes)
+- [ ] CA8 : Une fois lié, le bot répond normalement aux messages du `chat_id`, avec le `user_id` correspondant disponible pour construire le `TenantContext`
+
+**Notes fonctionnelles :**
+- Zone fonctionnelle concernée : interaction Telegram (nouvelle commande `/lier`, garde global) + PWA (écran de génération de code)
+- Migration BDD requise : **oui** — table ou colonnes pour les codes de liaison (`liaisons_telegram` : code, user_id, cree_le, expire_le, utilise_le), numéro de migration à vérifier au moment de l'implémentation
+- Dépendances : US-040 (colonne `users.telegram_chat_id` déjà prévue au socle tenant), US-044 (identité web nécessaire pour générer un code depuis un compte authentifié)
+- Impact tokens : **positif** — élimine les appels Groq déclenchés par des chats non identifiés (CA6)
+- Invariants projet : logging structuré conservé ; ordre critique des flux Telegram (cf. invariant #6 du backlog) impacté — le garde de liaison doit s'insérer AVANT les modes `corr_*` / `ask` / NAV existants, à documenter précisément dans l'implémentation
+
+**Notes techniques (pour Persona Developer) :**
+- Composants impactés : `bot.py` (nouvelle commande `/lier`, garde en tête de `handle_voice`/`handle_text`), nouveau service `services/liaison_telegram.py`, endpoint PWA `POST /auth/lien/generer-code`, migration SQL
+- Le message d'onboarding envoyé à un chat non lié doit être statique (pas d'appel LLM) pour respecter CA6
+- Prévoir l'échappement MarkdownV2 (invariant #7 du backlog) si le message d'onboarding contient des caractères spéciaux (ex. underscore dans une URL)
+- Documenter explicitement dans l'US d'implémentation la liste complète des points d'entrée Telegram concernés par le garde (voix, texte libre, et toutes les commandes slash existantes) pour éviter un oubli partiel
+- **Précision d'architecture — ne pas confondre deux identifiants distincts :** le bot Telegram (`@AssistantPotagerBot`, son token) est **unique et global** — tous les utilisateurs parlent au même backend `bot.py`. Le `chat_id`, lui, est **unique par utilisateur Telegram** (attribué par Telegram, pas par nous) et sert d'identifiant **stable et permanent** une fois lié — ce n'est pas un jeton de session ni un tunnel réseau. Après liaison, aucune ré-authentification n'est requise à chaque message : seul le `SELECT` `chat_id → user_id` est refait à chaque requête. La seule notion qui varie d'un message à l'autre est le **potager actif** (`users.potager_actif_id`, US-046), pas l'identité elle-même
+
+**Estimation :** 5 points
+
+**Scénario Gherkin :**
+```gherkin
+Scénario: Liaison réussie
+  Given un utilisateur connecté sur la PWA génère un code
+  When il envoie "/lier <code>" au bot dans les 10 minutes
+  Then son chat_id est lié à son compte
+  And les messages suivants de ce chat sont traités normalement
+
+Scénario: Code expiré
+  Given un code généré il y a plus de 10 minutes
+  When l'utilisateur envoie "/lier <code>" au bot
+  Then la liaison est refusée avec un message explicite
+
+Scénario: Code déjà utilisé
+  Given un code déjà consommé par une liaison précédente
+  When un autre utilisateur envoie "/lier <code>"
+  Then la liaison est refusée avec un message explicite
+
+Scénario: Chat_id déjà lié à un autre compte
+  Given un chat_id déjà lié au compte A
+  When une liaison est tentée vers le compte B avec ce même chat_id
+  Then la liaison est refusée avec un message explicite
+
+Scénario: Message d'un chat non lié
+  Given un chat_id qui n'a jamais été lié à un compte
+  When ce chat envoie un message vocal ou texte au bot
+  Then aucun appel Groq n'est déclenché
+  And le bot répond avec un message d'onboarding vers l'inscription web
+```
+
+**Labels GitHub :** `us`, `sprint-identite-acces`, `telegram`, `security`, `multi-tenant`

--- a/backlog/US-046_selection-potager-actif.md
+++ b/backlog/US-046_selection-potager-actif.md
@@ -1,0 +1,60 @@
+**ID :** US-046
+**Titre :** Sélectionner et changer de potager actif
+**Épic :** ÉPIC 2 — Identité & accès
+
+**Story :**
+En tant qu'utilisateur membre de plusieurs potagers
+Je veux choisir sur quel potager portent mes saisies et mes questions à un instant donné
+Afin de ne jamais enregistrer ou consulter des données dans le mauvais potager
+
+**Contexte fonctionnel :**
+Un même utilisateur peut appartenir à plusieurs potagers (table `potager_membres` du socle US-040). Depuis US-044/US-045, l'identité est établie côté web et Telegram, mais le `TenantContext` n'a pas encore de `potager_id` fiable dès qu'un utilisateur a plus d'un potager. Cette US introduit la notion de potager actif, mémorisée par utilisateur et utilisée pour construire le `TenantContext` de chaque requête, côté web comme côté Telegram.
+
+**Critères d'acceptance :**
+- [ ] CA1 : Un utilisateur membre d'un seul potager voit ce potager sélectionné automatiquement comme potager actif, sans action de sa part
+- [ ] CA2 : Un utilisateur membre de plusieurs potagers peut lister ses potagers via la commande `/potager` (Telegram, boutons inline) et via un sélecteur dans la PWA
+- [ ] CA3 : Le changement de potager actif est immédiatement pris en compte : toute saisie ou question suivante (bot ou PWA) porte sur le nouveau potager sélectionné
+- [ ] CA4 : Le potager actif est mémorisé par utilisateur (persistant entre sessions), pas seulement pour la durée d'une conversation
+- [ ] CA5 : Un utilisateur qui n'appartient à aucun potager reçoit un message clair l'invitant à en créer un ou à rejoindre un potager existant (renvoi vers le parcours de US-048)
+- [ ] CA6 : Le `TenantContext` construit à chaque requête (bot et API) utilise systématiquement le potager actif de l'utilisateur, sans valeur en dur
+
+**Notes fonctionnelles :**
+- Zone fonctionnelle concernée : interaction Telegram (commande `/potager`) + PWA (sélecteur de potager) + couche services (construction du `TenantContext`)
+- Migration BDD requise : **oui** — colonne `users.potager_actif_id` (nullable, FK vers `potagers`) ; peut être livrée avec US-045 dans la même migration si les deux US sont développées ensemble
+- Dépendances : US-040 (`potager_membres`), US-041 (`TenantContext`), US-045 (identité Telegram liée, nécessaire pour proposer `/potager` à un chat identifié)
+- Zéro impact tokens Groq (hors cas où le changement de potager déclenche un message de confirmation, négligeable)
+- Invariants projet : `TenantContext` reste construit une fois par requête dans la couche services, jamais recalculé ad hoc dans `bot.py`/`main.py`
+
+**Notes techniques (pour Persona Developer) :**
+- Composants impactés : `bot.py` (nouvelle commande `/potager` + callback inline de sélection), PWA (composant sélecteur), `services/` (fonction de résolution du `TenantContext` à partir de `users.potager_actif_id`), migration SQL
+- Le cas "sélection automatique silencieuse" (CA1) doit rester silencieux même si l'utilisateur rejoint un deuxième potager ultérieurement — à ce moment-là, bascule explicite requise (ne pas changer le potager actif sans action utilisateur)
+- Cette US ne gère pas la création de potager ni l'invitation de membres (US-048) — elle suppose que l'utilisateur est déjà membre d'au moins un potager pour les CA1-CA4
+- Prévoir l'invalidation du potager actif si l'utilisateur perd son accès (retrait par un owner, cf. US-048) — dépendance croisée à documenter, l'implémentation complète du retrait relève de US-048
+
+**Estimation :** 3 points
+
+**Scénario Gherkin :**
+```gherkin
+Scénario: Sélection automatique pour un seul potager
+  Given un utilisateur membre d'un seul potager
+  When il se connecte ou envoie un message au bot
+  Then ce potager est automatiquement son potager actif
+
+Scénario: Changement de potager actif via Telegram
+  Given un utilisateur membre de deux potagers "Jardin Nord" et "Jardin Sud"
+  When il envoie "/potager" et sélectionne "Jardin Sud"
+  Then son potager actif devient "Jardin Sud"
+  And ses saisies suivantes sont enregistrées dans "Jardin Sud"
+
+Scénario: Persistance entre sessions
+  Given un utilisateur a sélectionné "Jardin Sud" comme potager actif
+  When il ferme et rouvre la PWA le lendemain
+  Then "Jardin Sud" reste son potager actif
+
+Scénario: Utilisateur sans potager
+  Given un utilisateur n'appartient à aucun potager
+  When il tente de dicter une action
+  Then il reçoit un message l'invitant à créer ou rejoindre un potager
+```
+
+**Labels GitHub :** `us`, `sprint-identite-acces`, `telegram`, `pwa`, `multi-tenant`

--- a/backlog/US-047_roles-permissions-membres.md
+++ b/backlog/US-047_roles-permissions-membres.md
@@ -1,0 +1,67 @@
+**ID :** US-047
+**Titre :** Contrôler les actions par rôle (owner / editor / lecteur)
+**Épic :** ÉPIC 2 — Identité & accès
+
+**Story :**
+En tant que propriétaire d'un potager partagé
+Je veux que chaque membre n'agisse que selon le rôle qui lui a été attribué
+Afin qu'un simple lecteur ne puisse ni modifier ni supprimer des données, et que la gestion du potager reste réservée aux personnes de confiance
+
+**Contexte fonctionnel :**
+Le socle `potager_membres` (US-040) porte déjà un `role` (`owner`, `editor`, `lecteur`) mais rien ne le vérifie aujourd'hui. Cette US applique la matrice de permissions dans la couche services (US-041), au même endroit pour le bot et la PWA — un seul point de vérification, jamais dupliqué. Elle doit aussi couper court à l'appel LLM de parsing pour un lecteur qui dicterait une action, ce qui a un impact tokens positif direct.
+
+**Critères d'acceptance :**
+- [ ] CA1 : Un membre `lecteur` peut consulter (stats, historique, questions via `/ask`) mais toute tentative d'enregistrer, corriger ou supprimer un événement est refusée
+- [ ] CA2 : Un membre `editor` peut consulter et saisir/corriger/supprimer des événements, mais ne peut pas gérer les membres du potager ni ses paramètres
+- [ ] CA3 : Un membre `owner` a tous les droits de l'`editor`, plus la gestion des membres (invitation, changement de rôle, retrait) et la suppression du potager
+- [ ] CA4 : La vérification du rôle a lieu **avant** tout appel au parsing LLM (`parse_actions`) : un lecteur qui dicte "j'ai récolté 2 kg de tomates" ne déclenche aucun appel Groq, et reçoit un message expliquant qu'il n'a pas les droits nécessaires
+- [ ] CA5 : Le message de refus est explicite et cohérent entre le bot Telegram et la PWA (ex. « Tu es lecteur sur ce potager, tu ne peux pas enregistrer d'action »)
+- [ ] CA6 : La vérification de rôle est centralisée dans la couche services (garde unique, ex. `require_role(ctx, 'editor')`), jamais dupliquée dans `bot.py` ou `main.py`
+- [ ] CA7 : Une tentative d'action non autorisée est journalisée (log structuré) sans lever d'exception non gérée côté utilisateur
+
+**Notes fonctionnelles :**
+- Zone fonctionnelle concernée : couche services (garde de rôle) + interaction Telegram + PWA (messages d'erreur)
+- Migration BDD requise : **non** — la colonne `role` existe déjà depuis US-040 (`potager_membres.role`)
+- Dépendances : US-040 (`potager_membres.role`), US-041 (couche services centralisée), US-046 (potager actif, nécessaire pour savoir sur quel potager évaluer le rôle du membre)
+- Impact tokens : **positif** — blocage avant appel LLM pour les lecteurs (CA4), à mesurer et loguer comme les autres US touchant au coût Groq
+- Invariants projet : ordre critique des flux de conversation préservé — le garde de rôle s'insère dans le pipeline de traitement d'une action AVANT le parsing, sans perturber les modes `corr_*`/`ask` déjà en place (US-102/US-042)
+
+**Notes techniques (pour Persona Developer) :**
+- Composants impactés : `services/` (nouveau garde `require_role`, appliqué dans chaque fonction de service d'écriture : `enregistrer_evenement`, corrections, suppressions), `bot.py` et `main.py` (propagation du message de refus, pas de logique de rôle dupliquée)
+- La matrice de permissions (lecteur/editor/owner) doit être définie une seule fois, idéalement sous forme de table ou constante partagée, pour éviter toute divergence entre bot et PWA
+- La gestion des membres elle-même (invitation, changement de rôle, retrait) est développée dans US-048 — cette US se limite à faire respecter les rôles existants sur les actions déjà en place
+- Vérifier que le garde s'applique aussi aux endpoints REST de la PWA équivalents (pas seulement au bot), sous peine de contourner la protection via l'API directement
+
+**Estimation :** 5 points
+
+**Scénario Gherkin :**
+```gherkin
+Scénario: Lecteur bloqué avant appel LLM
+  Given un membre avec le rôle "lecteur" sur son potager actif
+  When il dicte "j'ai récolté 2 kg de tomates"
+  Then aucun appel au parsing LLM n'a lieu
+  And rien n'est enregistré
+  And il reçoit un message expliquant qu'il n'a pas les droits nécessaires
+
+Scénario: Lecteur autorisé en consultation
+  Given un membre avec le rôle "lecteur"
+  When il demande ses statistiques ou pose une question via /ask
+  Then la réponse lui est fournie normalement
+
+Scénario: Editor autorisé à saisir
+  Given un membre avec le rôle "editor"
+  When il dicte "j'ai récolté 2 kg de tomates"
+  Then l'événement est enregistré normalement
+
+Scénario: Editor refusé sur la gestion des membres
+  Given un membre avec le rôle "editor"
+  When il tente d'inviter un nouveau membre ou de changer un rôle
+  Then l'action est refusée avec un message explicite
+
+Scénario: Owner autorisé sur toutes les actions
+  Given un membre avec le rôle "owner"
+  When il gère les membres, saisit des événements ou consulte des données
+  Then toutes ces actions sont autorisées
+```
+
+**Labels GitHub :** `us`, `sprint-identite-acces`, `security`, `multi-tenant`, `permissions`

--- a/backlog/US-048_invitations-onboarding-self-service.md
+++ b/backlog/US-048_invitations-onboarding-self-service.md
@@ -1,0 +1,70 @@
+**ID :** US-048
+**Titre :** Créer un potager et inviter des membres en self-service
+**Épic :** ÉPIC 2 — Identité & accès
+
+**Story :**
+En tant que nouvel utilisateur ou propriétaire de potager
+Je veux créer un potager, inviter des membres et gérer leur accès sans intervention d'un administrateur
+Afin de pouvoir démarrer et faire vivre un potager partagé de bout en bout, de l'inscription à la première saisie vocale
+
+**Contexte fonctionnel :**
+C'est l'US qui referme le parcours complet de l'ÉPIC 2 : jusqu'ici, la création d'un potager et le rattachement d'un membre nécessitaient une opération manuelle (comme aujourd'hui pour le potager #1). Cette US rend tout le cycle self-service : inscription (US-044) → création ou adhésion à un potager → liaison Telegram (US-045) → sélection du potager actif (US-046) → première saisie, sans qu'un administrateur n'ait à toucher la base de données.
+
+**Critères d'acceptance :**
+- [ ] CA1 : Un utilisateur connecté peut créer un nouveau potager depuis la PWA en renseignant un nom et une localisation (latitude/longitude, ou adresse résolue en coordonnées) ; il en devient automatiquement `owner`
+- [ ] CA2 : La localisation saisie est celle qui alimentera la météo par potager dans une US ultérieure (US-124) — cette US se limite à la capturer et la stocker correctement
+- [ ] CA3 : Un `owner` peut inviter un membre par e-mail ou par lien/code d'invitation, en proposant un rôle (`editor` ou `lecteur`) au moment de l'invitation
+- [ ] CA4 : L'acceptation d'une invitation (par la personne invitée, après inscription si elle n'a pas encore de compte) insère une ligne dans `potager_membres` avec le rôle proposé
+- [ ] CA5 : Un `owner` peut retirer un membre de son potager à tout moment
+- [ ] CA6 : Un membre retiré perd l'accès immédiatement : son potager actif (US-046) est invalidé s'il pointait vers ce potager, et toute requête ultérieure sur ce potager est refusée
+- [ ] CA7 : Le parcours complet (inscription → création ou adhésion à un potager → liaison Telegram → première saisie vocale réussie) est réalisable sans aucune intervention manuelle en base de données ni sur le serveur
+- [ ] CA8 : Une invitation expirée ou déjà utilisée est refusée avec un message explicite, sur le même principe que le code de liaison Telegram (US-045)
+
+**Notes fonctionnelles :**
+- Zone fonctionnelle concernée : PWA (création de potager, gestion des membres, acceptation d'invitation) + couche services
+- Migration BDD requise : **oui** — table `invitations` (potager_id, email ou code, role_propose, cree_le, expire_le, utilisee_le), numéro de migration à vérifier au moment de l'implémentation
+- Dépendances : US-040 (`potagers`, `potager_membres`), US-041 (couche services), US-044 (identité web pour créer un compte et accepter une invitation), US-046 (invalidation du potager actif lors d'un retrait), US-047 (seul un `owner` peut inviter/retirer — la garde de rôle doit déjà être en place)
+- Zéro impact tokens Groq direct
+- Invariants projet : migration en fichier séparé idempotent avec rollback documenté ; envoi d'e-mail (si retenu pour l'invitation) doit être un service isolé et remplaçable, cohérent avec le choix technique déjà fait ou à faire pour la réinitialisation de mot de passe (US-044, hors périmètre)
+
+**Notes techniques (pour Persona Developer) :**
+- Composants impactés : nouveau service `services/potagers.py` (création, invitation, retrait de membre), nouveaux endpoints PWA (`POST /potagers`, `POST /potagers/{id}/invitations`, `POST /invitations/{code}/accepter`, `DELETE /potagers/{id}/membres/{user_id}`), migration SQL
+- Si l'envoi d'e-mail transactionnel n'est pas encore disponible dans le projet, prévoir en repli un lien/code d'invitation copiable manuellement (pas de blocage total de l'US pour cette raison) — à trancher explicitement dans le raffinement de l'US avant développement
+- CA6 (invalidation immédiate) dépend de la mécanique de potager actif de US-046 : vérifier que le retrait déclenche bien une resélection ou un message clair au prochain accès du membre retiré, pas une erreur technique brute
+- Le cas du dernier `owner` qui quitte ou retire son propre accès à un potager partagé n'est PAS couvert par cette US (transfert de propriété ou suppression du potager) — explicitement hors périmètre, à traiter dans US-132 (RGPD, suppression de compte) qui mentionne déjà ce risque
+
+**Estimation :** 8 points
+
+**Scénario Gherkin :**
+```gherkin
+Scénario: Création d'un potager
+  Given un utilisateur connecté sans potager
+  When il crée un potager avec un nom et une localisation
+  Then le potager est créé
+  And l'utilisateur en est owner
+  And ce potager devient son potager actif
+
+Scénario: Invitation et acceptation
+  Given un owner d'un potager
+  When il invite un nouvel utilisateur avec le rôle "editor"
+  And l'utilisateur invité accepte l'invitation
+  Then l'utilisateur invité devient membre du potager avec le rôle "editor"
+
+Scénario: Invitation expirée
+  Given une invitation générée il y a plus de son délai de validité
+  When l'invité tente de l'accepter
+  Then l'acceptation est refusée avec un message explicite
+
+Scénario: Retrait d'un membre
+  Given un owner et un membre "editor" sur le même potager
+  When l'owner retire ce membre
+  Then le membre perd immédiatement l'accès au potager
+  And si ce potager était son potager actif, il en est notifié au prochain accès
+
+Scénario: Parcours complet sans intervention manuelle
+  Given un nouvel utilisateur sans compte
+  When il s'inscrit, crée un potager, lie son compte Telegram et effectue sa première saisie vocale
+  Then toutes ces étapes réussissent sans aucune action d'un administrateur
+```
+
+**Labels GitHub :** `us`, `sprint-identite-acces`, `pwa`, `onboarding`, `multi-tenant`

--- a/docs/ANALYSE_pepiniere_multi_emplacements.md
+++ b/docs/ANALYSE_pepiniere_multi_emplacements.md
@@ -1,0 +1,97 @@
+# Analyse — Suivi spatial de la pépinière (préparation US)
+
+> Document d'analyse technique, à destination de l'agent PO pour la rédaction d'une future User Story.
+> Ce n'est **pas** une US formatée — c'est le constat qui doit nourrir sa rédaction.
+> Date de l'analyse : 2026-07-17.
+
+## Contexte
+
+En validant l'US-041 (couche `app/services/`) sur une base de dev contenant 6 parcelles dont une
+serre marquée pépinière (`est_pepiniere = true`), un comportement a été observé : la vue **Plan**
+du dashboard n'affiche jamais rien sur la parcelle Serre, alors que la vue **Stocks > Pépinière**
+affiche bien des plants en godet et des semis en attente. Cette différence a été investiguée — ce
+n'est pas un bug, c'est la conséquence directe de la logique existante décrite ci-dessous.
+
+## Constat — comportement actuel
+
+### 1. Le Plan ignore délibérément les parcelles pépinière
+
+`calcul_occupation_parcelles()` (`utils/parcelles.py:387`) ne peuple une parcelle qu'à partir de
+deux types d'événements :
+- `plantation`, sans restriction
+- `semis`, **uniquement si la parcelle n'est pas marquée `est_pepiniere`** (`_cond_semis_pleine_terre`,
+  introduite en migration_v13 / US-037)
+
+Un semis rattaché à une parcelle pépinière est donc **explicitement exclu** de l'occupation du sol.
+C'est un choix voulu : le Plan sert à la rotation de culture en pleine terre, pas au suivi de la
+pépinière.
+
+### 2. Les mises en godet ne sont jamais localisées, quel que soit le nombre de pépinières
+
+Un événement `mise_en_godet` est créé avec `parcelle_id = NULL` codé en dur
+(`app/services/evenements.py::creer_evenement_godet`, hérité du comportement historique de
+`bot.py::_save_godet_item`). Peu importe où sont physiquement les godets (serre, châssis, étagère
+intérieure...), l'événement n'est **jamais** rattaché à une parcelle. Avoir plusieurs parcelles
+pépinière ne change donc rien pour les godets : ils ne sont localisés nulle part.
+
+### 3. Les stocks de pépinière sont agrégés uniquement par (culture, variété), jamais par lieu
+
+`calcul_godets()` et `calcul_semis()` (`utils/stock.py`) — utilisés par les endpoints
+`GET /godets`, `GET /godets/detail`, `GET /stats` et par `/stats` côté bot — regroupent les
+événements pépinière (semis + godets) exclusivement par `(culture, variété)`. La parcelle
+d'origine n'entre jamais dans la clé d'agrégation.
+
+## Problème identifié
+
+**Le modèle de données actuel ne supporte pas plusieurs emplacements de pépinière distincts.**
+
+Si un jardinier déclare deux parcelles pépinière (ex. "Serre" et "Châssis froid") et sème 50 graines
+de carotte dans l'une et 30 dans l'autre :
+- Le Plan continuera de ne rien afficher pour aucune des deux — cohérent avec l'existant, pas de
+  régression.
+- Stocks > Pépinière affichera **"carotte : 80 graines"** en un seul bloc, sans aucun moyen de
+  savoir que c'est réparti sur deux emplacements physiques différents.
+- Les godets liés à ces semis (mise en godet) resteront non localisés dans tous les cas, comme
+  aujourd'hui avec une seule pépinière.
+
+Ajouter une deuxième parcelle `est_pepiniere = true` ne casse rien, mais n'apporte aucune valeur :
+le modèle n'a tout simplement pas la notion de "quelle pépinière".
+
+## Cas d'usage potentiellement concernés
+
+- Jardinier avec plusieurs zones de semis (serre chauffée + châssis froid + étagère intérieure) qui
+  veut savoir ce qui occupe chaque zone, pas seulement le total par culture.
+- Question du type *"est-ce que j'ai encore de la place dans ma serre ?"* — actuellement sans
+  réponse possible via l'application, malgré la donnée `superficie_m2` déjà présente sur la
+  parcelle Serre.
+- Futur multi-tenant (potager partagé) : deux jardiniers du même potager pourraient chacun gérer
+  une pépinière distincte (ex. balcon perso vs serre commune) — la distinction devient encore plus
+  utile dans ce contexte.
+
+## Pistes de solution (non tranchées — à la charge de la future US)
+
+1. **A minima** : ajouter une vue "occupation de la pépinière" à part (distincte du Plan pleine
+   terre), qui affiche par parcelle pépinière les semis qui y sont rattachés — sans toucher aux
+   godets ni à l'agrégation existante.
+2. **Plus complet** : rattacher les mises en godet à une parcelle (rendre `parcelle_id` optionnel
+   mais renseignable pour `mise_en_godet`, avec sélection à la dictée comme pour les autres
+   actions), puis inclure la parcelle dans la clé d'agrégation de `calcul_godets()`/`calcul_semis()`.
+3. Dans tous les cas : décider si l'agrégat "toutes pépinières confondues" doit rester affiché par
+   défaut (utile pour une vue rapide) avec un détail par emplacement en option, ou l'inverse.
+
+## Composants techniques concernés (pour la future US)
+
+| Fichier | Rôle actuel |
+|---------|-------------|
+| `utils/parcelles.py::calcul_occupation_parcelles` | Exclut les semis pépinière du Plan (`_cond_semis_pleine_terre`) |
+| `utils/stock.py::calcul_godets` | Agrège les godets par (culture, variété), sans notion de parcelle |
+| `utils/stock.py::calcul_semis` | Agrège les semis par (culture, variété), sans notion de parcelle |
+| `app/services/evenements.py::creer_evenement_godet` | Crée toujours l'événement avec `parcelle_id = NULL` |
+| `database/models.py::Parcelle.est_pepiniere` | Flag booléen existant, actuellement binaire (pépinière ou non), pas d'identification de laquelle en aval |
+
+## Hors périmètre de cette analyse
+
+- Aucun changement de code n'a été fait suite à ce constat — c'est un sujet à part, indépendant de
+  l'US-041 (couche services) qui l'a fait remonter.
+- La priorisation (est-ce un besoin réel maintenant, ou théorique) reste à évaluer côté produit
+  avant rédaction de l'US.

--- a/docs/prompt frontend agent.md
+++ b/docs/prompt frontend agent.md
@@ -1,0 +1,99 @@
+
+---
+
+## BESOIN BRUT
+
+Créer une interface web de visualisation des données techniques du potager, permettant à l'admin de consulter l'état du jardin, l'historique des actions et les indicateurs clés issus de l'application Assistant Potager.
+
+---
+
+## CONTRAINTES TECHNIQUES
+
+| Contrainte            | Détail                                                                 |
+|-----------------------|------------------------------------------------------------------------|
+| **Infrastructure**    | VPS Scaleway — 1 Go RAM, plusieurs services actifs (FastAPI, PostgreSQL, uvicorn) |
+| **Déploiement front** | Netlify (build statique) ou VPS selon complexité                       |
+| **Performance**       | Pas de critère strict — privilégier la stabilité sur la rapidité       |
+| **Appels API**        | Via endpoints FastAPI existants — pas d'accès direct à la BDD côté front |
+| **Auth**              | Simple (token statique ou session) — admin seul, pas de gestion de rôles |
+
+---
+
+## CONVENTIONS UI/UX (non négociables)
+
+Tout développement front doit respecter ces choix de librairies. Aucun composant custom n'est autorisé si une librairie couvre le besoin.
+
+| Rôle              | Librairie / Outil     | Remarque                                      |
+|-------------------|-----------------------|-----------------------------------------------|
+| Design system     | **Tailwind CSS**      | Classes utilitaires uniquement, pas de CSS custom |
+| Composants UI     | **Shadcn/UI**         | Badge, Alert, DataTable, Progress, Toast      |
+| Graphiques        | **Recharts**          | AreaChart, LineChart, BarChart, RadialBar     |
+| Icônes            | **Lucide React**      | Cohérence visuelle garantie                   |
+| Tables filtrables | **TanStack Table**    | Via composant DataTable Shadcn                |
+
+### Standard de rendu visuel
+
+- Références : style **Vercel Analytics** (densité d'info, lisibilité) et **Tremor.so** (composants data-centric)
+- Palette : tons verts et bruns cohérents avec le domaine potager
+- Responsive : **mobile-first** — 1 colonne < 768px, 2-3 colonnes desktop
+- États obligatoires sur chaque composant : `loading skeleton`, `erreur`, `données vides`
+- Dark/light mode : supporté dès la phase 1
+
+---
+
+## CATALOGUE COMPOSANTS PAR TYPE DE DONNÉE
+
+Le PO doit s'appuyer sur ce catalogue pour renseigner la section "Composant UI ciblé" de chaque US.
+
+| Type de donnée            | Librairie   | Composant recommandé               | Exemple d'usage potager                     |
+|---------------------------|-------------|------------------------------------|---------------------------------------------|
+| Évolution temporelle      | Recharts    | `<AreaChart />` / `<LineChart />`  | Température serre, arrosage cumulé          |
+| Comparaison par catégorie | Recharts    | `<BarChart />`                     | Rendement par variété, semis vs récoltes    |
+| Indicateur d'état courant | Shadcn/UI   | `<Badge />` + `<Progress />`       | Humidité sol, stade de croissance           |
+| Inventaire / tableau      | Shadcn/UI   | `<DataTable />` (TanStack)         | Liste semis, planning récoltes              |
+| Alerte / seuil critique   | Shadcn/UI   | `<Alert />` + `<Toast />`          | Gel prévu, stock critique, seuil arrosage   |
+| Taux / proportion         | Recharts    | `<RadialBarChart />`               | Taux de germination, taux de réussite semis |
+
+---
+
+## QUESTIONS DE CADRAGE — À TRAITER AVANT GÉNÉRATION DES US
+
+Le PO doit répondre aux questions suivantes et intégrer les réponses dans le contexte de chaque US produite.
+
+1. **Données prioritaires** : parmi température serre, historique arrosage, stocks semis, stades de croissance, alertes — lesquelles constituent le MVP ?
+2. **Fréquence de mise à jour** : rafraîchissement manuel (bouton), automatique (polling toutes X minutes), ou temps réel (WebSocket) ?
+3. **Appareil principal** : l'admin consulte-t-il principalement sur desktop ou mobile (téléphone au jardin) ?
+4. **Horizon temporel des graphiques** : 7 jours, 30 jours, saison complète — quelle granularité par défaut ?
+5. **Durée de vie** : MVP rapide à valider en 1 sprint, ou socle évolutif prévu sur plusieurs mois ?
+
+---
+
+## TEMPLATE US OBLIGATOIRE
+
+Chaque US générée doit strictement respecter cette structure.
+
+```markdown
+# US : [Titre court]
+
+**En tant que** : Admin
+**Je veux** : [action observable]
+**Afin que** : [valeur métier ou gain concret]
+
+## Critères d'acceptation
+- [ ] ...
+- [ ] États gérés : loading skeleton, erreur API, données vides
+
+## Composant UI ciblé
+| Élément       | Librairie   | Composant exact         | Props / variante        |
+|---------------|-------------|-------------------------|-------------------------|
+| [ex: graphe]  | Recharts    | `<AreaChart />`         | données : endpoint /... |
+| [ex: badge]   | Shadcn/UI   | `<Badge variant="...">' | vert=ok, rouge=alerte   |
+
+## Données affichées
+- **Source** : endpoint FastAPI `/api/...` (à créer si inexistant)
+- **Format** : JSON `{ clé: valeur }`
+- **Fréquence refresh** : [manuel / polling Xmin / WebSocket]
+
+## Risques / Notes techniques
+- [impact RAM VPS si polling fréquent, etc.]
+```

--- a/migrations/consolidation_liens_pepiniere.sql
+++ b/migrations/consolidation_liens_pepiniere.sql
@@ -1,0 +1,107 @@
+-- ============================================================
+-- Consolidation liens pépinière — 2026-06-09
+-- Harmonisation variétés + liens origine_graines_id + source_evenement_ids
+-- ============================================================
+
+BEGIN;
+
+-- ── BLOC 1 : Harmonisation des noms de variété ────────────────
+
+-- blette : "poirée verte" → "poirées"
+UPDATE evenements SET variete = 'poirées'
+WHERE culture = 'blette' AND variete = 'poirée verte';
+
+-- courgette : "Gold Rush jaune" → "jaune"
+UPDATE evenements SET variete = 'jaune'
+WHERE culture = 'courgette' AND variete = 'Gold Rush jaune';
+
+-- tomate : "ronde noire de Crimée" → "noire de Crimée"
+UPDATE evenements SET variete = 'noire de Crimée'
+WHERE culture = 'tomate' AND variete = 'ronde noire de Crimée';
+
+
+-- ── BLOC 2 : Liens godet → semis (origine_graines_id) ────────
+
+-- courgette/jaune (godet id=93) → semis id=56
+UPDATE evenements SET origine_graines_id = 56
+WHERE id = 93 AND type_action = 'mise_en_godet';
+
+
+-- ── BLOC 3 : Liens plantation → godet(s) (source_evenement_ids) ──
+
+-- blette/poirées
+UPDATE evenements SET source_evenement_ids = '173'
+WHERE id = 174 AND type_action = 'plantation';
+
+-- cornichon/petit Paris
+UPDATE evenements SET source_evenement_ids = '170'
+WHERE id IN (171, 183) AND type_action = 'plantation';
+
+-- courgette/verte
+UPDATE evenements SET source_evenement_ids = '121'
+WHERE id = 180 AND type_action = 'plantation';
+
+-- courgette/jaune
+UPDATE evenements SET source_evenement_ids = '93'
+WHERE id = 179 AND type_action = 'plantation';
+
+-- tomate/cerise
+UPDATE evenements SET source_evenement_ids = '118'
+WHERE id = 189 AND type_action = 'plantation';
+
+-- tomate/noire de Crimée
+UPDATE evenements SET source_evenement_ids = '116'
+WHERE id = 193 AND type_action = 'plantation';
+
+-- potiron (sans variété) — FIFO : lot le plus ancien d'abord (id=123)
+UPDATE evenements SET source_evenement_ids = '123'
+WHERE id = 195 AND type_action = 'plantation';
+
+-- tomate/cœur de bœuf — allocation FIFO (godets id=114 puis id=120)
+-- id=181 : 14 plants → 14 sur les 20 de id=114
+UPDATE evenements SET source_evenement_ids = '114'
+WHERE id = 181 AND type_action = 'plantation';
+
+-- id=192 : 9 plants → 6 restants de id=114 + 3 de id=120
+UPDATE evenements SET source_evenement_ids = '114;120'
+WHERE id = 192 AND type_action = 'plantation';
+
+-- id=194 : 3 plants → id=120
+UPDATE evenements SET source_evenement_ids = '120'
+WHERE id = 194 AND type_action = 'plantation';
+
+-- id=197 : 3 plants → id=120
+UPDATE evenements SET source_evenement_ids = '120'
+WHERE id = 197 AND type_action = 'plantation';
+
+
+-- ── VÉRIFICATION post-application ────────────────────────────
+
+SELECT
+    e.id,
+    e.date::date,
+    e.type_action,
+    e.culture,
+    e.variete,
+    e.origine_graines_id,
+    e.source_evenement_ids,
+    CASE
+        WHEN e.type_action = 'mise_en_godet' AND e.origine_graines_id IS NULL    THEN '⚠ semis manquant'
+        WHEN e.type_action = 'plantation'    AND e.source_evenement_ids IS NULL   THEN '⚠ godet manquant'
+        ELSE 'OK'
+    END AS statut
+FROM evenements e
+WHERE e.id IN (
+    93, 173, 174,
+    170, 171, 183,
+    121, 180,
+    93, 179,
+    118, 189,
+    116, 193,
+    123, 195,
+    114, 120, 181, 192, 194, 197,
+    56
+)
+ORDER BY e.culture, e.type_action, e.id;
+
+COMMIT;


### PR DESCRIPTION
## Summary
- Recupere le commit `24da5c7` (branche `fix/potager-user-createrole`), reste isole apres le merge de la PR #108 (CREATEROLE) et jamais fusionne ailleurs.
- Ajoute le backlog complet de l'epic 2 identite/acces : US-044 (auth web JWT), US-045 (liaison Telegram <-> compte web), US-046 (selection du potager actif), US-047 (roles/permissions membres), US-048 (invitations/onboarding self-service).
- Ajoute l'analyse pepiniere multi-emplacements et un script SQL de consolidation des liens pepiniere.

## Contexte
`epic-2-identite-acces` s'est reveleee etre un ancetre pur de `dev` (tout son contenu est deja dans `dev`, sans rien d'unique) - cette PR cible donc `dev` directement plutot que l'ancienne branche epic-2, qui est obsolete.

## Test plan
- [x] Cherry-pick propre, sans conflit
- Documentation uniquement, aucun changement de code

---

## Jira US
**US-044** : PIA-35
**US-045** : PIA-36
**US-046** : PIA-37
**US-047** : PIA-38
**US-048** : PIA-39

_Rattachement rétroactif (backfill Jira) — livré dans PATCH_NOTES.md : v3.20.0 (2026-07-20); v3.21.0 (2026-07-20); v3.23.0 (2026-07-22); v3.24.0 (2026-07-25)._
