### PR TITLE
fix(bot): corrige le crash lors de la sélection de variété en callback (cherry-pick dev)

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -2698,7 +2698,7 @@ async def _parse_and_save(update: Update, texte: str, msg=None, pre_parsed_items
                     cb    = v["variete"] if v["variete"] else "__none__"
                     buttons.append([InlineKeyboardButton(f"🌿 {var} ({stock} plants actifs)", callback_data=f"perte_var_j:{cb}")])
                 buttons.append([InlineKeyboardButton("❌ Annuler", callback_data="perte_cancel")])
-                await update.message.reply_text(
+                await message.reply_text(
                     f"🌿 Quelle variété de *{_md(culture)}* au potager ?",
                     parse_mode="Markdown", reply_markup=InlineKeyboardMarkup(buttons),
                 )
@@ -2735,7 +2735,7 @@ async def _parse_and_save(update: Update, texte: str, msg=None, pre_parsed_items
                     cb  = g["variete"] if g["variete"] else "__none__"
                     buttons.append([InlineKeyboardButton(f"🪴 {var} ({g['stock_residuel_godet']} en godet)", callback_data=f"perte_var_p:{cb}")])
                 buttons.append([InlineKeyboardButton("❌ Annuler", callback_data="perte_cancel")])
-                await update.message.reply_text(
+                await message.reply_text(
                     f"🪴 Quelle variété de *{_md(culture)}* en pépinière ?",
                     parse_mode="Markdown", reply_markup=InlineKeyboardMarkup(buttons),
                 )
@@ -2769,7 +2769,7 @@ async def _parse_and_save(update: Update, texte: str, msg=None, pre_parsed_items
                 [InlineKeyboardButton("❌ Annuler",   callback_data="perte_cancel")],
             ]
             var_lbl = f" *{variete}*" if variete else ""
-            await update.message.reply_text(
+            await message.reply_text(
                 f"🤔 Perte de *{qte} {culture_md}*{var_lbl} — au potager ou en pépinière ?",
                 parse_mode="Markdown",
                 reply_markup=InlineKeyboardMarkup(buttons),
@@ -2798,7 +2798,7 @@ async def _parse_and_save(update: Update, texte: str, msg=None, pre_parsed_items
                     for v in jardin_actif
                 ]
                 buttons_var.append([InlineKeyboardButton("❌ Annuler", callback_data="perte_cancel")])
-                await update.message.reply_text(
+                await message.reply_text(
                     f"🌿 Quelle variété de *{_md(culture)}* avez-vous perdu ?",
                     parse_mode="Markdown",
                     reply_markup=InlineKeyboardMarkup(buttons_var),
@@ -2845,7 +2845,7 @@ async def _parse_and_save(update: Update, texte: str, msg=None, pre_parsed_items
                     ]
                     buttons.append([InlineKeyboardButton("📍 Sans parcelle", callback_data="action_parcelle_none")])
                     log.info(f"[US-021 CA8] {len(parcelles_culture)} parcelles pour {culture!r} — user_id={user_id}")
-                    await update.message.reply_text(
+                    await message.reply_text(
                         summary + f"\n\n*Dans quelle parcelle ?* _(parcelles avec {culture})_",
                         parse_mode="Markdown",
                         reply_markup=InlineKeyboardMarkup(buttons),


### PR DESCRIPTION
## Résumé
Cherry-pick du hotfix mergé dans `dev` via #117.

- `_parse_and_save()` utilisait `update.message.reply_text(...)` à 5 endroits au lieu de la variable locale `message` (`= update.message or update.callback_query.message`)
- Quand la fonction est relancée depuis un callback inline (ex: choix de variété après une récolte ambiguë), `update.message` est `None` → `AttributeError` → l'événement n'est jamais enregistré
- Correctif déjà validé et déployé sur `dev` via #117

## Test plan
- [x] `python -m pytest tests/` — aucune régression (mêmes échecs préexistants avant/après)
- [ ] Vérifier en prod après déploiement : récolter une culture avec plusieurs variétés sans préciser la variété, sélectionner via le menu inline

🤖 Generated with [Claude Code](https://claude.com/claude-code)