### PR TITLE
fix(auth) + docs: message post-inscription US-044, backlog US-051

### DIFF
--- a/backlog/US-051_attribution-pertes-parcelle-exacte.md
+++ b/backlog/US-051_attribution-pertes-parcelle-exacte.md
@@ -1,0 +1,43 @@
+**ID :** US-051
+**Titre :** Attribuer les pertes et récoltes de plants à leur parcelle exacte dans le plan d'occupation
+
+**Story :**
+En tant que jardinier
+Je veux que la perte ou la récolte d'une culture ne réduise le nombre de plants affiché que sur la parcelle réellement concernée
+Afin de voir dans le plan d'occupation du dashboard un stock par parcelle fiable, cohérent avec le stock global affiché par `/stats`
+
+**Critères d'acceptance :**
+- [ ] CA1 : Quand un événement `perte` (ou `récolte` en pièces, culture végétative) précise une `parcelle_id`, seule cette parcelle voit son nombre de plants diminuer dans le plan d'occupation — les autres parcelles portant la même culture/variété ne sont pas affectées.
+- [ ] CA2 : Quand un événement `perte`/`récolte` ne précise aucune parcelle, le comportement de secours actuel est conservé : répartition proportionnelle du montant entre toutes les parcelles plantées de cette culture/variété (pour ne jamais faire disparaître la perte du calcul).
+- [ ] CA3 : Le total de plants affiché (toutes parcelles confondues) dans le plan d'occupation reste toujours égal au stock global calculé par `/stats` Telegram, quel que soit le nombre de parcelles portant la même culture/variété.
+- [ ] CA4 : Une variété plantée sur plusieurs parcelles, avec une perte localisée sur une seule d'entre elles, ne fait plus disparaître à tort le stock des autres parcelles (cas constaté en prod v3.14 sur le basilic, corrigé en urgence par une répartition proportionnelle temporaire dans US précédent — cette US remplace cette approximation par une attribution exacte).
+- [ ] CA5 : Un test de non-régression couvre explicitement ce scénario : 2 parcelles avec la même variété, perte localisée sur une seule parcelle via `parcelle_id`, vérification que seule cette parcelle est impactée.
+- [ ] CA6 : Aucune régression sur les scénarios existants (perte avec variété unique sur une seule parcelle, perte sans variété, perte sans parcelle précisée).
+
+**Notes fonctionnelles :**
+- Zone fonctionnelle concernée : consultation (plan d'occupation des parcelles, dashboard)
+- Migration BDD requise : non — `Evenement.parcelle_id` existe déjà pour les événements `perte` et `recolte`
+- Dépendances : correctif d'urgence déjà livré (répartition proportionnelle des pertes/récoltes "avec variété", v3.14.1 sur `main` / v3.25.1 sur `dev`) — cette US en est le raffinement définitif, remplace la logique de prorata par une attribution directe quand la parcelle est connue
+- Fichier concerné (pour référence fonctionnelle uniquement) : logique de calcul du plan d'occupation par parcelle
+
+**Estimation :** 3 points
+
+**Scénario Gherkin :**
+```gherkin
+Scénario : Perte localisée sur une seule parcelle parmi plusieurs portant la même variété
+  Given deux parcelles "A" et "B" plantées chacune de 10 plants de basilic "grand vert"
+  And une perte de 10 plants de basilic "grand vert" enregistrée avec la parcelle "A"
+  When je consulte le plan d'occupation des parcelles
+  Then la parcelle "A" affiche 0 plant de basilic
+  And la parcelle "B" affiche toujours 10 plants de basilic
+  And le total (0 + 10) correspond au stock global renvoyé par /stats
+
+Scénario : Perte sans parcelle précisée (comportement de secours)
+  Given deux parcelles "A" et "B" plantées chacune de 10 plants de basilic "grand vert"
+  And une perte de 2 plants de basilic "grand vert" enregistrée sans parcelle précisée
+  When je consulte le plan d'occupation des parcelles
+  Then la perte est répartie proportionnellement entre "A" et "B"
+  And le total affiché sur les deux parcelles reste égal à 18
+```
+
+**Labels GitHub :** `us`, `bug`, `stock`, `dashboard`

--- a/frontend/src/views/Auth.jsx
+++ b/frontend/src/views/Auth.jsx
@@ -2,12 +2,23 @@
 import { useState } from 'react'
 import { useAuth } from '../context/AuthContext.jsx'
 
+function IconOeil({ barre }) {
+  return (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M1 12s4-7 11-7 11 7 11 7-4 7-11 7-11-7-11-7Z" />
+      <circle cx="12" cy="12" r="3" />
+      {barre && <line x1="2" y1="22" x2="22" y2="2" />}
+    </svg>
+  )
+}
+
 export default function Auth() {
   const { login, register, loading, error, errorCode, resendVerification } = useAuth()
   const [mode, setMode] = useState('login') // 'login' | 'register'
   const [email, setEmail] = useState('')
   const [motDePasse, setMotDePasse] = useState('')
   const [message, setMessage] = useState(null)
+  const [afficherMdp, setAfficherMdp] = useState(false)
 
   async function handleResend() {
     setMessage(null)
@@ -20,11 +31,20 @@ export default function Auth() {
     setMessage(null)
 
     if (mode === 'login') {
-      await login(email, motDePasse)
+      const ok = await login(email, motDePasse)
+      if (!ok) {
+        setMotDePasse('')
+        setAfficherMdp(false)
+      }
     } else {
       const ok = await register(email, motDePasse)
+      setMotDePasse('')
+      setAfficherMdp(false)
       if (ok) {
-        setMessage('Compte créé — vous pouvez maintenant vous connecter.')
+        setMessage(
+          "Compte créé — un e-mail de vérification vient d'être envoyé à votre adresse. " +
+            'Cliquez sur le lien reçu pour activer votre compte avant de vous connecter.'
+        )
         setMode('login')
       }
     }
@@ -60,15 +80,34 @@ export default function Auth() {
             onChange={(e) => setEmail(e.target.value)}
             style={inputStyle}
           />
-          <input
-            type="password"
-            required
-            minLength={8}
-            placeholder="Mot de passe (8 caractères min.)"
-            value={motDePasse}
-            onChange={(e) => setMotDePasse(e.target.value)}
-            style={inputStyle}
-          />
+          <div style={{ position: 'relative' }}>
+            <input
+              type={afficherMdp ? 'text' : 'password'}
+              required
+              minLength={8}
+              placeholder="Mot de passe (8 caractères min.)"
+              value={motDePasse}
+              onChange={(e) => setMotDePasse(e.target.value)}
+              style={{ ...inputStyle, width: '100%', paddingRight: 40 }}
+            />
+            <button
+              type="button"
+              onClick={() => setAfficherMdp((v) => !v)}
+              aria-label={afficherMdp ? 'Masquer le mot de passe' : 'Afficher le mot de passe'}
+              title={afficherMdp ? 'Masquer le mot de passe' : 'Afficher le mot de passe'}
+              style={{
+                position: 'absolute',
+                right: 10,
+                top: '50%',
+                transform: 'translateY(-50%)',
+                color: 'var(--g-sec)',
+                lineHeight: 0,
+                padding: 4,
+              }}
+            >
+              <IconOeil barre={afficherMdp} />
+            </button>
+          </div>
 
           {error && <p style={{ color: 'var(--g-red)', fontSize: 13 }}>{error}</p>}
           {errorCode === 'EMAIL_NOT_VERIFIED' && (
@@ -100,7 +139,12 @@ export default function Auth() {
         </form>
 
         <button
-          onClick={() => { setMode(mode === 'login' ? 'register' : 'login'); setMessage(null) }}
+          onClick={() => {
+            setMode(mode === 'login' ? 'register' : 'login')
+            setMessage(null)
+            setMotDePasse('')
+            setAfficherMdp(false)
+          }}
           style={{ color: 'var(--g-sec)', fontSize: 13, marginTop: 16, width: '100%', textAlign: 'center' }}
         >
           {mode === 'login' ? "Pas encore de compte ? S'inscrire" : 'Déjà un compte ? Se connecter'}


### PR DESCRIPTION
## Résumé
- fix(auth) : corrige le message post-inscription et la persistance du mot de passe (US-044), déjà committé sur epic-2-identite-acces après le merge de la PR #121
- docs(backlog) : ajoute l'US-051 (attribution des pertes/récoltes de plants à la parcelle exacte, raffinement définitif du hotfix v3.14.1/v3.25.1 déjà déployé)

Une fois mergée, la branche `epic-2-identite-acces` peut être clôturée/supprimée.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

---

## Jira US
**US-044** : PIA-35
**US-051** : PIA-42

_Rattachement rétroactif (backfill Jira) — livré dans PATCH_NOTES.md : v3.27.0 (2026-08-11)._
